### PR TITLE
fix: fix advance setting blocking the control center

### DIFF
--- a/src/window/imsettingwindow.h
+++ b/src/window/imsettingwindow.h
@@ -51,6 +51,7 @@ class DBusProvider;
 class IMConfig;
 class AdvanceConfig;
 class ConfigSettings;
+class QProcess;
 
 class IMSettingWindow : public QWidget
 {
@@ -95,6 +96,7 @@ private:
     dcc_fcitx_configtool::widgets::FcitxSettingsHead *m_editHead {nullptr}; //编辑按钮
     dcc_fcitx_configtool::widgets::FcitxComBoboxSettingsItem *m_imSwitchCbox {nullptr}; //切换输入法（快捷键）
     dcc_fcitx_configtool::widgets::FcitxKeySettingsItem *m_defaultIMKey {nullptr}; //默认输入法（快捷键）
+    QProcess *m_advSetProcess;
     QPushButton* m_advSetKey  {nullptr}; //高级设置
     Dtk::Widget::DCommandLinkButton* m_resetBtn {nullptr}; //重置输入法（快捷键）
     Dtk::Widget::DFloatingButton *m_addIMBtn {nullptr}; //添加输入法


### PR DESCRIPTION
* system 改为 QProcess，避免阻塞
* 当高级设置进程存在时，不能再次打开
* 切换页面后，关闭高级设置

Log: 修复输入法高级设置阻塞控制中心
Bug: https://pms.uniontech.com/bug-view-172459.html, https://pms.uniontech.com/bug-view-183039.html