### PR TITLE
fix: 修复输入方式设置页面按钮没翻译

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(IsoCodes REQUIRED)
 configure_file(config.h.in config.h)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
+add_compile_definitions(FCITX_GETTEXT_DOMAIN="fcitx5-configtool")
+
 #加载子目录
 add_subdirectory(src)
 


### PR DESCRIPTION
增加 gettext domain，使用 fcitx5-configtool 的翻译

Fixes linuxdeepin/developer-center#3600

Log: 修复输入方式设置页面按钮没翻译