### PR TITLE
fix: 修复切换输入法快捷键显示错误

### DIFF
--- a/src/window/imsettingwindow.cpp
+++ b/src/window/imsettingwindow.cpp
@@ -258,7 +258,8 @@ void IMSettingWindow::initConnect()
     });
 
     connect(m_advanceConfig, &AdvanceConfig::switchFirstIMShortCutsChanged, this, [=](const QString& shortCuts) {
-        m_defaultIMKey->setList(shortCuts.split("+"));
+        // 只需要第一组快捷键
+        m_defaultIMKey->setList(shortCuts.split(" ").first().split("+"));
     });
 
     connect(m_resetBtn, &QPushButton::clicked, [ = ]() {


### PR DESCRIPTION
切换输入法可以有多组快捷键（使用空格分隔），
只显示第一个

Fixes linuxdeepin/developer-center#3839