### PR TITLE
fix: Missing line splitter for enabled language

### DIFF
--- a/src/addim/configlib/model.cpp
+++ b/src/addim/configlib/model.cpp
@@ -267,6 +267,9 @@ void AvailIMModel::filterIMEntryList(
         }
         m_filteredIMEntryList[idx].second.append(im);
     }
+
+    setUseIMLanguageCount(m_enabledIMs.count());
+
     endResetModel();
 }
 


### PR DESCRIPTION
  Add line splitter, and it's linewidth and color is flowing the
top splitter.

Issue: https://github.com/linuxdeepin/developer-center/issues/3690