### PR TITLE
feat: improve keyboard layout indication

### DIFF
--- a/src/addim/widgetslib/impage.cpp
+++ b/src/addim/widgetslib/impage.cpp
@@ -238,18 +238,29 @@ void IMPage::availIMCurrentChanged(const QModelIndex &index)
     m_childIMList->setCurrentIndex(defaultChild);
 }
 
-void IMPage::childIMSelectionChanged(const QItemSelection &selection)
+void IMPage::childIMSelectionChanged()
 {
-    m_buttonTuple->rightButton()->setEnabled(!selection.isEmpty());
+    auto selected = m_childIMList->selectionModel()->selectedIndexes();
 
-    for (auto &i : selection.indexes()) {
-        QString uniqueName = i.data(FcitxIMUniqueNameRole).toString();
+    m_buttonTuple->rightButton()->setEnabled(!selected.isEmpty());
 
-        QString layout;
-        QString variant;
-        std::tie(layout, variant) = getLayoutString(uniqueName);
-        m_laSelector->setKeyboardLayout(layout, variant);
+    if (selected.isEmpty()) {
+        m_laSelector->showNoLayout();
+        return;
     }
+
+    if (selected.count() > 1) {
+        m_laSelector->showMulti();
+        return;
+    }
+
+    QModelIndex i = selected.at(0);
+    QString uniqueName = i.data(FcitxIMUniqueNameRole).toString();
+
+    QString layout;
+    QString variant;
+    std::tie(layout, variant) = getLayoutString(uniqueName);
+    m_laSelector->setKeyboardLayout(layout, variant);
 }
 
 void IMPage::clickedFindMoreButton()

--- a/src/addim/widgetslib/impage.h
+++ b/src/addim/widgetslib/impage.h
@@ -46,7 +46,7 @@ public slots:
 
 private slots:
     void availIMCurrentChanged(const QModelIndex &index);
-    void childIMSelectionChanged(const QItemSelection &selection);
+    void childIMSelectionChanged();
 
     void clickedFindMoreButton();
 

--- a/src/addim/widgetslib/layoutwidget.h
+++ b/src/addim/widgetslib/layoutwidget.h
@@ -9,6 +9,10 @@
 
 struct xkb_context;
 
+class QLabel;
+
+enum class LayoutStatus;
+
 class LayoutWidget : public DTK_WIDGET_NAMESPACE::DFrame
 {
     Q_OBJECT
@@ -18,6 +22,8 @@ public:
     ~LayoutWidget();
 
     void setKeyboardLayout(const QString &layout, const QString &variant = QString());
+    void showMulti();
+    void showNoLayout();
 
 protected:
     void paintEvent(QPaintEvent *event) override;
@@ -25,10 +31,15 @@ protected:
 private:
     xkb_context *m_ctx;
 
+    LayoutStatus m_status;
     std::string m_layout;
     std::string m_variant;
+    
+    QLabel *m_label;
 
     void paintLayout(QPainter &painter);
+    void showNoLayoutLabel();
+    void showMultiLayoutLabel();
 };
 
 #endif

--- a/translations/deepin-fcitx5configtool-plugin.ts
+++ b/translations/deepin-fcitx5configtool-plugin.ts
@@ -48,6 +48,19 @@
     </message>
 </context>
 <context>
+    <name>LayoutWidget</name>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="264"/>
+        <source>The current input method has no keyboard layout</source>
+        <translation>The current input method has no keyboard layout</translation>
+    </message>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="270"/>
+        <source>Multiple input methods have been selected</source>
+        <translation>Multiple input methods have been selected</translation>
+    </message>
+</context>
+<context>
     <name>dcc_fcitx_configtool::widgets::FcitxKeyLabelWidget</name>
     <message>
         <location filename="../src/widgets/keysettingsitem.cpp" line="31"/>
@@ -71,22 +84,22 @@
 <context>
     <name>fcitx::addim::IMPage</name>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="59"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="78"/>
         <source>Select your language and add input methods</source>
         <translation type="unfinished">Select your language and add input methods</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="131"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="139"/>
         <source>Find more in App Store</source>
         <translation>Find more in App Store</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="142"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="150"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="145"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="153"/>
         <source>Add</source>
         <translation>Add</translation>
     </message>

--- a/translations/deepin-fcitx5configtool-plugin_en_US.ts
+++ b/translations/deepin-fcitx5configtool-plugin_en_US.ts
@@ -48,6 +48,19 @@
     </message>
 </context>
 <context>
+    <name>LayoutWidget</name>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="264"/>
+        <source>The current input method has no keyboard layout</source>
+        <translation>The current input method has no keyboard layout</translation>
+    </message>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="270"/>
+        <source>Multiple input methods have been selected</source>
+        <translation>Multiple input methods have been selected</translation>
+    </message>
+</context>
+<context>
     <name>dcc_fcitx_configtool::widgets::FcitxKeyLabelWidget</name>
     <message>
         <location filename="../src/widgets/keysettingsitem.cpp" line="31"/>
@@ -71,22 +84,22 @@
 <context>
     <name>fcitx::addim::IMPage</name>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="59"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="78"/>
         <source>Select your language and add input methods</source>
         <translation type="unfinished">Select your language and add input methods</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="131"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="139"/>
         <source>Find more in App Store</source>
         <translation>Find more in App Store</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="142"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="150"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="145"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="153"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/deepin-fcitx5configtool-plugin_zh_CN.ts
+++ b/translations/deepin-fcitx5configtool-plugin_zh_CN.ts
@@ -48,6 +48,19 @@
     </message>
 </context>
 <context>
+    <name>LayoutWidget</name>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="264"/>
+        <source>The current input method has no keyboard layout</source>
+        <translation>当前输入法无键盘样式</translation>
+    </message>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="270"/>
+        <source>Multiple input methods have been selected</source>
+        <translation>已选定多个输入法</translation>
+    </message>
+</context>
+<context>
     <name>dcc_fcitx_configtool::widgets::FcitxKeyLabelWidget</name>
     <message>
         <location filename="../src/widgets/keysettingsitem.cpp" line="31"/>
@@ -71,22 +84,22 @@
 <context>
     <name>fcitx::addim::IMPage</name>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="59"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="78"/>
         <source>Select your language and add input methods</source>
         <translation type="unfinished">选择使用语言并添加输入法</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="131"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="139"/>
         <source>Find more in App Store</source>
         <translation>前往商店下载</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="142"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="150"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="145"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="153"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>

--- a/translations/deepin-fcitx5configtool-plugin_zh_HK.ts
+++ b/translations/deepin-fcitx5configtool-plugin_zh_HK.ts
@@ -48,6 +48,19 @@
     </message>
 </context>
 <context>
+    <name>LayoutWidget</name>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="264"/>
+        <source>The current input method has no keyboard layout</source>
+        <translation>當前輸入法無鍵盤樣式</translation>
+    </message>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="270"/>
+        <source>Multiple input methods have been selected</source>
+        <translation>已選定多個輸入法</translation>
+    </message>
+</context>
+<context>
     <name>dcc_fcitx_configtool::widgets::FcitxKeyLabelWidget</name>
     <message>
         <location filename="../src/widgets/keysettingsitem.cpp" line="31"/>
@@ -71,22 +84,22 @@
 <context>
     <name>fcitx::addim::IMPage</name>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="59"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="78"/>
         <source>Select your language and add input methods</source>
         <translation type="unfinished">選擇使用語言並添加輸入法</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="131"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="139"/>
         <source>Find more in App Store</source>
         <translation>前往商店下載</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="142"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="150"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="145"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="153"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>

--- a/translations/deepin-fcitx5configtool-plugin_zh_TW.ts
+++ b/translations/deepin-fcitx5configtool-plugin_zh_TW.ts
@@ -48,6 +48,19 @@
     </message>
 </context>
 <context>
+    <name>LayoutWidget</name>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="264"/>
+        <source>The current input method has no keyboard layout</source>
+        <translation>當前輸入法無鍵盤樣式</translation>
+    </message>
+    <message>
+        <location filename="../src/addim/widgetslib/layoutwidget.cpp" line="270"/>
+        <source>Multiple input methods have been selected</source>
+        <translation>已選定多個輸入法</translation>
+    </message>
+</context>
+<context>
     <name>dcc_fcitx_configtool::widgets::FcitxKeyLabelWidget</name>
     <message>
         <location filename="../src/widgets/keysettingsitem.cpp" line="31"/>
@@ -71,22 +84,22 @@
 <context>
     <name>fcitx::addim::IMPage</name>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="59"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="78"/>
         <source>Select your language and add input methods</source>
         <translation type="unfinished">選擇使用語言並添加輸入法</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="131"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="139"/>
         <source>Find more in App Store</source>
         <translation>前往商店下載</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="142"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="150"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../src/addim/widgetslib/impage.cpp" line="145"/>
+        <location filename="../src/addim/widgetslib/impage.cpp" line="153"/>
         <source>Add</source>
         <translation>添加</translation>
     </message>


### PR DESCRIPTION
* When no keyboard layout is available for the selected input method,
 display: 'The current input method has no keyboard layout'
* When multiple input methods are selected,
 display: 'Multiple input methods have been selected'

Fixes linuxdeepin/developer-center#3681