### PR TITLE
fix: the actions in the list are displayed incorrectly

### DIFF
--- a/src/window/imsettingwindow.cpp
+++ b/src/window/imsettingwindow.cpp
@@ -156,7 +156,9 @@ void IMSettingWindow::initUI()
             this,
             [this](const QModelIndex &current, [[maybe_unused]] const QModelIndex &previous) {
                 m_deleteBtn->setEnabled(current.isValid());
-                updateActions();
+                QTimer::singleShot(0, [this]() {
+                    updateActions();
+                });
             });
 
     QHBoxLayout *shortcutLayout = new QHBoxLayout();


### PR DESCRIPTION
The actions for the previously selected IM are not hidden after selecting a new IM.