### PR TITLE
chore: change plugin installation directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,7 +190,7 @@ endif ()
 # 设置执行 make install 时哪个目标应该被 install 到哪个位置
 
 if(NOT ${CMAKE_BUILD_TYPE} MATCHES "Debug")
-    install(TARGETS ${BIN_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/dde-control-center/modules)
+    install(TARGETS ${BIN_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/dde-control-center/modules)
 endif()
 
 add_subdirectory(layout)


### PR DESCRIPTION
Use `CMAKE_INSTALL_FULL_LIBDIR` instead of `CMAKE_INSTALL_LIBDIR`