### PR TITLE
fix: 打开高级设置后切换页面控制中心崩溃

### DIFF
--- a/src/addim/configlib/model.cpp
+++ b/src/addim/configlib/model.cpp
@@ -178,7 +178,7 @@ QVariant AvailIMModel::dataForCategory(const QModelIndex &index,
 
     // 设置背景色
     case Dtk::ViewItemBackgroundRole:
-        return QVariant::fromValue(QPair<int, int>{QPalette::Base, DPalette::NoType});
+        return QVariant::fromValue(QPair<int, int>{QPalette::Base, Dtk::Gui::DPalette::NoType});
 
     default:
         return QVariant();
@@ -211,7 +211,7 @@ QVariant AvailIMModel::dataForItem(const QModelIndex &index, int role) const {
 
     // 设置背景色
     case Dtk::ViewItemBackgroundRole:
-        return QVariant::fromValue(QPair<int, int>{QPalette::Base, DPalette::NoType});
+        return QVariant::fromValue(QPair<int, int>{QPalette::Base, Dtk::Gui::DPalette::NoType});
 
     }
     return QVariant();

--- a/src/window/imsettingwindow.cpp
+++ b/src/window/imsettingwindow.cpp
@@ -40,50 +40,6 @@ DWIDGET_USE_NAMESPACE
 
 using namespace dcc_fcitx_configtool::widgets;
 
-class EventConsumer : public QEventLoop
-{
-public:
-    explicit EventConsumer(QObject *producer = qApp, QObject *parent = nullptr);
-    ~EventConsumer() override;
-    bool eventFilter(QObject *watched, QEvent *event) override;
-
-private:
-    QObject *m_producer;
-};
-
-EventConsumer::EventConsumer(QObject *producer, QObject *parent)
-    : QEventLoop(parent)
-    , m_producer(producer)
-{
-    if (m_producer) {
-        m_producer->installEventFilter(this);
-    }
-}
-
-EventConsumer::~EventConsumer()
-{
-    if (m_producer) {
-        m_producer->removeEventFilter(this);
-    }
-}
-
-bool EventConsumer::eventFilter(QObject *watched, QEvent *event)
-{
-    Q_UNUSED(watched)
-    switch (event->type())
-    {
-    case QEvent::MouseButtonPress:
-    case QEvent::MouseButtonRelease:
-    case QEvent::MouseButtonDblClick:
-    case QEvent::MouseMove:
-    case QEvent::KeyPress:
-    case QEvent::KeyRelease:
-        return true;
-    default:
-        return false;
-    }
-}
-
 IMSettingWindow::IMSettingWindow(DBusProvider *dbus, QWidget *parent)
     : QWidget(parent)
     , m_dbus(dbus)
@@ -274,18 +230,23 @@ void IMSettingWindow::initConnect()
         });
     });
 
-    connect(m_advSetKey, &QPushButton::clicked, this, [ = ]() {
-        QProcess advancedSettingProcess(this);
-        advancedSettingProcess.setProgram("fcitx5-config-qt");
-        EventConsumer loop;
-        advancedSettingProcess.start();
+    connect(m_advSetKey, &QPushButton::clicked, this, [this]() {
+        m_advSetKey->setEnabled(false);
+        auto *advancedSettingProcess = new QProcess(this);
+        advancedSettingProcess->setProgram("fcitx5-config-qt");
+        advancedSettingProcess->start();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 13, 0)
         auto finished = QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished);
 #else
         auto finished = QOverload<int>::of(&QProcess::finished);
 #endif
-        connect(&advancedSettingProcess, finished, &loop, &EventConsumer::quit);
-        loop.exec();
+        auto conn = connect(advancedSettingProcess, finished, this, [this] () {
+            m_advSetKey->setEnabled(true);
+        });
+
+        connect(this, &QObject::destroyed, [conn]() {
+            disconnect(conn);
+        });
     });
 }
 


### PR DESCRIPTION
不使用 EventConsumer，在点击打开高级设置按钮后，禁用高级设置按钮

Issues linuxdeepin/developer-center#6552