### PR TITLE
feat: Add fcitx5 global config page

### DIFF
--- a/src/dcc-fcitx5configtool/CMakeLists.txt
+++ b/src/dcc-fcitx5configtool/CMakeLists.txt
@@ -18,7 +18,7 @@ ADD_DEFINITIONS("-fstack-protector-strong -D_FORTITY_SOURCE=1 -z noexecstack -pi
 # find_package(QT NAMES Qt6 Qt5)
 # set(QT_MAJOR_VERSION 6)
 # set(QT_DEFAULT_MAJOR_VERSION 6)
-find_package(Qt6 COMPONENTS Core Gui DBus LinguistTools REQUIRED)
+find_package(Qt6 COMPONENTS Core Gui DBus LinguistTools Qml REQUIRED)
 find_package(DdeControlCenter REQUIRED)
 find_package(Dtk6 COMPONENTS Core REQUIRED)
 find_package(PkgConfig REQUIRED)
@@ -29,6 +29,7 @@ file(GLOB_RECURSE DccFcitx5configtool_SRCS
         "operation/qrc/*.qrc"
         "*.cpp"
         "*.h"
+        "private/*.h"
         "operation/*.cpp"
         "operation/*.h"
 )
@@ -46,6 +47,7 @@ target_include_directories(${DccFcitx5configtool_Name} PUBLIC
 set(DccFcitx5configtool_Libraries
         Qt${QT_MAJOR_VERSION}::DBus
         Qt${QT_MAJOR_VERSION}::Gui
+        Qt${QT_MAJOR_VERSION}::Qml
         Dtk${QT_MAJOR_VERSION}::Core
         Dde::Control-Center
 )

--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
@@ -1,0 +1,226 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "fcitx5configproxy.h"
+#include "private/fcitx5configproxy_p.h"
+
+#include <dbusprovider.h>
+#include <varianthelper.h>
+
+#include <QDBusPendingCallWatcher>
+
+using namespace deepin::fcitx5configtool;
+
+Fcitx5ConfigProxyPrivate::Fcitx5ConfigProxyPrivate(Fcitx5ConfigProxy *parent,
+                                                 fcitx::kcm::DBusProvider *dbus,
+                                                 const QString &path)
+    : q(parent), dbusprovider(dbus), path(path)
+{
+    timer = new QTimer(q);
+    timer->setInterval(1000);
+    timer->setSingleShot(true);
+    connect(timer, &QTimer::timeout, q, &Fcitx5ConfigProxy::save);
+}
+
+QStringList Fcitx5ConfigProxyPrivate::formatKey(const QString &shortcut) {
+    QStringList list;
+    for (const auto &key : shortcut.split("+")) {
+        if (key.trimmed().toLower() == "control")
+            list << "Ctrl";
+        else if (key.trimmed().toLower() == "backspace")
+            list << "Backspace";
+        else if (key.trimmed().toLower() == "space")
+            list << "Space";
+        else
+            list << key.trimmed();
+    }
+    return list;
+}
+
+QString Fcitx5ConfigProxyPrivate::formatKeys(const QStringList &keys) {
+    QStringList list;   
+    for (const auto &key : keys) {
+        if (key.trimmed().toLower() == "ctrl")
+            list << "Control";
+        else if (key.trimmed().toLower() == "backspace")
+            list << "BackSpace";
+        else if (key.trimmed().toLower() == "space")
+            list << "space";
+        else
+            list << key.trimmed();
+    }
+    return list.join("+");
+}
+
+QVariant Fcitx5ConfigProxyPrivate::readDBusValue(const QVariant &value) {
+    if (value.canConvert<QDBusArgument>()) {
+        auto argument = qvariant_cast<QDBusArgument>(value);
+        QVariantMap map;
+        argument >> map;
+        
+        QVariantMap resultMap;
+        for (auto iter = map.begin(); iter != map.end(); ++iter) {
+            resultMap[iter.key()] = readDBusValue(iter.value());
+        }
+        return resultMap;
+    }
+    
+    if (value.type() == QVariant::Map) {
+        QVariantMap resultMap;
+        const auto map = value.toMap();
+        for (auto iter = map.begin(); iter != map.end(); ++iter) {
+            resultMap[iter.key()] = readDBusValue(iter.value());
+        }
+        return resultMap;
+    }
+    
+    return value;
+}
+
+Fcitx5ConfigProxy::Fcitx5ConfigProxy(fcitx::kcm::DBusProvider *dbus, const QString &path, QObject *parent)
+    : QObject(parent), d(new Fcitx5ConfigProxyPrivate(this, dbus, path))
+{
+}
+
+Fcitx5ConfigProxy::~Fcitx5ConfigProxy() = default;
+
+QVariantList Fcitx5ConfigProxy::globalConfigTypes() const
+{
+    QVariantList list;
+    for (const auto &type : d->configTypes) {
+        if (type.name() == "GlobalConfig") {
+            for (const auto &option : type.options()) {
+                QVariantMap item;
+                item["name"] = option.name();
+                item["description"] = option.description();
+                list.append(item);
+            }
+            break;
+        }
+    }
+    return list;
+}
+
+QVariantList Fcitx5ConfigProxy::globalConfigOptions(const QString &type) const
+{
+    QVariantList list;
+    QString currentType = type+"$"+type+"Config";
+    for (const auto &configType : d->configTypes) {
+        if (configType.name() != currentType)
+            continue;
+        for (const auto &option : configType.options()) {
+            QVariantMap item;
+            item["name"] = option.name();
+            item["type"] = option.type();
+            item["description"] = option.description();
+            auto variant = value(type+"/"+option.name());
+            if (variant.type() == QVariant::Map) {
+                QVariantMap map = variant.toMap();
+                if (map.contains("0")) {
+                    item["value"] = d->formatKey(map["0"].toString());
+                }
+            } else {
+                item["value"] = variant;
+            }
+            
+            QVariantMap properties = option.properties();
+            if (!properties.isEmpty()) {
+                auto iterator = properties.begin();
+                while (iterator != properties.constEnd()) {
+                    if (iterator.key() == "Enum") {
+                        auto argument = qvariant_cast<QDBusArgument>(iterator.value());
+                        QVariantMap map;
+                        argument >> map;
+                        QVariantList enumStrings = map.values().toList();
+                        if (!enumStrings.isEmpty()) {
+                            item["properties"] = enumStrings;
+                        }
+                        break;
+                    }
+                    ++iterator;
+                }
+                iterator = properties.begin();
+                while (iterator != properties.constEnd()) {
+                    if (iterator.key() == "EnumI18n") {
+                        auto argument = qvariant_cast<QDBusArgument>(iterator.value());
+                        QVariantMap map;
+                        argument >> map;
+                        QVariantList enumStrings = map.values().toList();
+                        if (!enumStrings.isEmpty()) {
+                            item["propertiesI18n"] = enumStrings;
+                        }
+                        break;
+                    }
+                    ++iterator;
+                }
+            }
+            list.append(item);
+        }
+        break;
+    }
+    return list;
+}
+
+void Fcitx5ConfigProxy::requestConfig(bool sync)
+{
+    if (!d->dbusprovider->controller()) {
+        return;
+    }
+    auto call = d->dbusprovider->controller()->GetConfig(d->path);
+    auto watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher,
+            &QDBusPendingCallWatcher::finished,
+            this,
+            &Fcitx5ConfigProxy::onRequestConfigFinished);
+    if (sync) {
+        watcher->waitForFinished();
+    }
+}
+ 
+void Fcitx5ConfigProxy::onRequestConfigFinished(QDBusPendingCallWatcher *watcher)
+{
+    watcher->deleteLater();
+    QDBusPendingReply<QDBusVariant, fcitx::FcitxQtConfigTypeList> reply = *watcher;
+    if (reply.isError()) {
+        qWarning() << reply.error();
+        return;
+    }
+    d->configTypes = reply.argumentAt<1>(); 
+
+    auto value = reply.argumentAt<0>().variant();
+    QVariantMap allMap;
+    allMap = d->readDBusValue(value).toMap();
+    std::swap(d->configValue, allMap);
+
+    Q_EMIT requestConfigFinished();
+}
+
+QVariant Fcitx5ConfigProxy::value(const QString &path) const
+{
+    return fcitx::kcm::readVariant(d->configValue, path);
+}
+
+void Fcitx5ConfigProxy::setValue(const QString &path, const QVariant &value, bool isKey)
+{
+    if (value == this->value(path))
+        return;
+    if (isKey) {
+        auto keys = d->formatKey(value.toString());
+        fcitx::kcm::writeVariant(d->configValue, path + "/0", keys);
+    } else {
+        fcitx::kcm::writeVariant(d->configValue, path, value);
+    }
+    d->timer->start();
+}
+
+void Fcitx5ConfigProxy::save()
+{
+    if (!d->dbusprovider->controller()) {
+        return;
+    }
+
+    QDBusVariant var(d->configValue);
+    d->dbusprovider->controller()->SetConfig(d->path, var);
+    requestConfig(false);
+}

--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.h
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FCITX5CONFIGPROXY_H
+#define FCITX5CONFIGPROXY_H
+
+#include <QMap>
+#include <QObject>
+#include <QVariant>
+
+namespace fcitx::kcm {
+class DBusProvider;
+}
+
+class QDBusPendingCallWatcher;
+
+namespace deepin {
+namespace fcitx5configtool {
+class Fcitx5ConfigProxyPrivate;
+class Fcitx5ConfigProxy : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit Fcitx5ConfigProxy(fcitx::kcm::DBusProvider *dbus,
+                         const QString &path,
+                         QObject *parent = nullptr);
+    ~Fcitx5ConfigProxy();
+
+Q_SIGNALS:
+    void requestConfigFinished();
+
+public Q_SLOTS:
+    QVariant value(const QString &path) const;
+    void setValue(const QString &path, const QVariant &value, bool isKey = false);
+    void save();
+    QVariantList globalConfigTypes() const;
+    QVariantList globalConfigOptions(const QString &type) const;
+    void requestConfig(bool sync);
+
+private Q_SLOTS:
+    void onRequestConfigFinished(QDBusPendingCallWatcher *watcher);
+
+private:
+    friend class Fcitx5ConfigProxyPrivate;
+    Fcitx5ConfigProxyPrivate *const d;
+};
+}   // namespace fcitx5configtool
+}   // namespace deepin 
+
+#endif // !FCITX5CONFIGPROXY_H

--- a/src/dcc-fcitx5configtool/operation/fcitx5configtool.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configtool.cpp
@@ -2,22 +2,65 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "fcitx5configtool.h"
+#include "private/fcitx5configtool_p.h"
+#include "fcitx5configproxy.h"
+
+#include "dbusprovider.h"
+#include "imconfig.h"
+#include "model.h"
 
 #include "dde-control-center/dccfactory.h"
+
+#include <fcitxqtdbustypes.h>
 
 #include <QCoreApplication>
 #include <QDebug>
 #include <QGuiApplication>
 #include <QtQml/QQmlEngine>
 
-// #include "dccfactory.h"
-
 namespace deepin {
 namespace fcitx5configtool {
-Fcitx5ConfigToolWorker::Fcitx5ConfigToolWorker(QObject *parent)
-    : QObject(parent)
-{
 
+static QString kFcitxConfigGlobalPath = "fcitx://config/global";
+
+Fcitx5ConfigToolWorkerPrivate::Fcitx5ConfigToolWorkerPrivate(Fcitx5ConfigToolWorker *parent)
+    : QObject(parent), q(parent)
+{
+    
+}
+
+void Fcitx5ConfigToolWorkerPrivate::init()
+{
+    dbusProvider = new fcitx::kcm::DBusProvider(this);
+    imConfig = new fcitx::kcm::IMConfig(dbusProvider, fcitx::kcm::IMConfig::Tree, this);
+    configProxy = new Fcitx5ConfigProxy(dbusProvider, kFcitxConfigGlobalPath, this);
+    initConnect();
+}
+
+void Fcitx5ConfigToolWorkerPrivate::initConnect()
+{
+    connect(imConfig, &fcitx::kcm::IMConfig::imListChanged, this, [=]() {
+        qInfo() << "list changed:" << imConfig->currentIMModel()->rowCount();
+    });
+    connect(configProxy, &Fcitx5ConfigProxy::requestConfigFinished, q, &Fcitx5ConfigToolWorker::requestConfigFinished);
+    configProxy->requestConfig(false);
+}
+
+Fcitx5ConfigToolWorker::Fcitx5ConfigToolWorker(QObject *parent)
+    : QObject(parent), d(new Fcitx5ConfigToolWorkerPrivate(this))
+{
+    qmlRegisterType<Fcitx5ConfigProxy>("com.deepin.dcc.fcitx5configtool", 1, 0, "Fcitx5ConfigProxy");
+    QMetaObject::invokeMethod(this, "init", Qt::QueuedConnection);
+}
+
+void Fcitx5ConfigToolWorker::init()
+{
+    d->init();
+}
+
+Fcitx5ConfigProxy *Fcitx5ConfigToolWorker::fcitx5ConfigProxy() const
+{
+    return d->configProxy;
 }
 
 DCC_FACTORY_CLASS(Fcitx5ConfigToolWorker)

--- a/src/dcc-fcitx5configtool/operation/fcitx5configtool.h
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configtool.h
@@ -4,21 +4,36 @@
 #ifndef FCITX5CONFIGTOOL_H
 #define FCITX5CONFIGTOOL_H
 
+#include "fcitx5configproxy.h"
+
 #include <QObject>
 #include <QVariant>
 #include <QVariantMap>
 
 namespace deepin {
 namespace fcitx5configtool {
-
+class Fcitx5ConfigToolWorkerPrivate;
 class Fcitx5ConfigToolWorker : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(Fcitx5ConfigProxy* fcitx5ConfigProxy READ fcitx5ConfigProxy NOTIFY requestConfigFinished)
 
 public:
     explicit Fcitx5ConfigToolWorker(QObject *parent = nullptr);
-};
-} // namespace fcitx5configtool
-} // namespace deepin
 
-#endif // FCITX5CONFIGTOOL_H
+    Fcitx5ConfigProxy *fcitx5ConfigProxy() const;
+
+Q_SIGNALS:
+    void requestConfigFinished();
+
+protected Q_SLOTS:
+    void init();
+
+private:
+    friend class Fcitx5ConfigToolWorkerPrivate;
+    Fcitx5ConfigToolWorkerPrivate *const d;
+};
+}   // namespace fcitx5configtool
+}   // namespace deepin
+
+#endif   // FCITX5CONFIGTOOL_H

--- a/src/dcc-fcitx5configtool/operation/private/fcitx5configproxy_p.h
+++ b/src/dcc-fcitx5configtool/operation/private/fcitx5configproxy_p.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef FCITX5CONFIGPROXY_P_H
+#define FCITX5CONFIGPROXY_P_H
+
+#include <fcitxqtdbustypes.h>
+
+#include <QObject>
+
+class QTimer;
+
+namespace fcitx::kcm {
+class DBusProvider;
+}
+
+namespace deepin {
+namespace fcitx5configtool {
+class Fcitx5ConfigProxy;
+class Fcitx5ConfigProxyPrivate : public QObject
+{
+    Q_OBJECT
+    friend class Fcitx5ConfigProxy;
+    Fcitx5ConfigProxy *const q;
+
+public:
+    explicit Fcitx5ConfigProxyPrivate(Fcitx5ConfigProxy *parent,
+                                     fcitx::kcm::DBusProvider *dbus,
+                                     const QString &path);
+    QStringList formatKey(const QString &shortcut);
+    QString formatKeys(const QStringList &keys);
+    QVariant readDBusValue(const QVariant &value);
+
+private:
+    fcitx::kcm::DBusProvider *dbusprovider;
+    QString path;
+    QVariantMap configValue;
+    fcitx::FcitxQtConfigTypeList configTypes;
+    QTimer *timer {nullptr};
+};
+}   // namespace fcitx5configtool
+}   // namespace deepin
+
+#endif // FCITX5CONFIGPROXY_P_H 

--- a/src/dcc-fcitx5configtool/operation/private/fcitx5configtool_p.h
+++ b/src/dcc-fcitx5configtool/operation/private/fcitx5configtool_p.h
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef FCITX5CONFIGTOOL_P_H
+#define FCITX5CONFIGTOOL_P_H
+
+#include <QObject>
+#include <QVariant>
+#include <QVariantMap>
+
+namespace fcitx::kcm {
+class IMConfig;
+class DBusProvider;
+}
+
+namespace deepin {
+namespace fcitx5configtool {
+class Fcitx5ConfigProxy;
+class Fcitx5ConfigToolWorker;
+class Fcitx5ConfigToolWorkerPrivate : public QObject
+{
+    Q_OBJECT
+    friend class Fcitx5ConfigToolWorker;
+    Fcitx5ConfigToolWorker *const q;
+
+    fcitx::kcm::IMConfig *imConfig { nullptr };
+    fcitx::kcm::DBusProvider *dbusProvider { nullptr };
+    Fcitx5ConfigProxy *configProxy { nullptr };
+
+private:
+    void init();
+    void initConnect();
+
+public:
+    explicit Fcitx5ConfigToolWorkerPrivate(Fcitx5ConfigToolWorker *parent = nullptr);
+};
+}   // namespace fcitx5configtool
+}   // namespace deepin
+
+#endif   // FCITX5CONFIGTOOL_P_H

--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+import QtQuick 2.15
+import QtQuick.Layouts 1.15
+import QtQuick.Controls 2.3
+import QtQuick.Window 2.15
+import org.deepin.dtk 1.0 as D
+import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc 1.0
+
+DccObject {
+    id: root
+    DccObject {
+        name: root.displayName
+        parentName: "GlobalConfigPage"
+        weight: 40
+        hasBackground: true
+        pageType: DccObject.Item
+        page: DccGroupView {
+            spacing: 0
+            height: implicitHeight + 30
+        }
+    }
+    
+    DccObject {
+        id: headerItem
+        property bool expanded: true
+        parentName: root.displayName
+        displayName: root.displayName
+        hasBackground: true
+        weight: 10
+        pageType: DccObject.Item
+        page: RowLayout {
+            Label {
+                Layout.leftMargin: 10
+                font: D.DTK.fontManager.t4
+                text: dccObj.displayName
+            }
+            D.IconButton {
+                icon.width: 12
+                icon.height: 12
+                implicitWidth: 12
+                implicitHeight: 12
+                anchors {
+                    right: parent.right
+                    rightMargin: 0
+                    top: parent.top
+                    topMargin: (parent.height - height) / 2 - 2
+                }
+                icon.name: headerItem.expanded ? "go-down" : "go-next"
+                flat: true
+                onClicked: headerItem.expanded = !headerItem.expanded
+            }
+        }
+    }
+
+    property var configOptions: []
+
+    Component.onCompleted: {
+        dccData.fcitx5ConfigProxy.onRequestConfigFinished.connect(() => {
+            configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
+        })
+        configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
+        loading = false
+    }
+
+    Loader {
+        active: !loading
+        asynchronous: true
+        sourceComponent: DccRepeater {
+            model: configOptions
+            delegate: Component {
+                DccObject {
+                    parentName: root.displayName
+                    displayName: modelData.description
+                    hasBackground: true
+                    weight: 10
+                    pageType: DccObject.Editor
+                    visible: headerItem.expanded
+                    page: Loader {
+                        sourceComponent: {
+                            switch(modelData.type) {
+                                case "Boolean":
+                                    return booleanComponent
+                                case "Integer":
+                                    return integerComponent  
+                                case "String":
+                                    return stringComponent
+                                case "List|Key":
+                                    return keyComponent
+                                case "Enum":
+                                    return enumComponent
+                                default:
+                                    return null
+                            }
+                        }
+
+                        Component {
+                            id: booleanComponent
+                            D.Switch {
+                                checked: modelData.value === "True"
+                                onCheckedChanged: {
+                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name, checked.toString())
+                                }
+                            }
+                        }
+
+                        Component {
+                            id: integerComponent
+                            D.SpinBox {
+                                width: 55
+                                implicitWidth: 55
+                                value: parseInt(modelData.value)
+                                onValueChanged: {
+                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name, value.toString())
+                                }
+                            }
+                        }
+
+                        Component {
+                            id: stringComponent
+                            D.TextField {
+                                text: modelData.value
+                                onTextChanged: {
+                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name, text)
+                                }
+                            }
+                        }
+
+                        Component {
+                            id: keyComponent
+                            D.KeySequenceEdit {
+                                placeholderText: qsTr("Please enter a new shortcut")
+                                keys: modelData.value
+                                background.visible: false
+                                onKeysChanged: {
+                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name + "/0", keys, true)
+                                }
+                            }
+                        }
+
+                        Component {
+                            id: enumComponent
+                            D.ComboBox {
+                                model: modelData.propertiesI18n
+                                width: 100
+                                flat: true
+                                currentIndex: modelData.properties.indexOf(modelData.value) ? modelData.properties.indexOf(modelData.value) : 0
+                                onCurrentIndexChanged: {
+                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name, modelData.properties[currentIndex])
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/dcc-fcitx5configtool/qml/GlobalConfigPage.qml
+++ b/src/dcc-fcitx5configtool/qml/GlobalConfigPage.qml
@@ -1,8 +1,27 @@
 // SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import Qt.labs.platform 1.1
+import Qt.labs.qmlmodels 1.2
 
 import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
 
-DccObject {}
+import org.deepin.dcc 1.0
+import com.deepin.dcc.fcitx5configtool 1.0
+
+DccObject {
+    id: root
+    property bool loading: true
+    
+    DccRepeater {
+        model: dccData.fcitx5ConfigProxy.globalConfigTypes()
+        delegate: Component {
+            DetailConfigItem {
+                name: modelData.name
+                displayName: modelData.description
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add Qt6::Qml dependency for QML support
- Create fcitx5 config proxy and worker classes
- Implement global config page with dynamic config items
- Add DetailConfigItem component for different config types

Log: Add fcitx5 global config page