### PR TITLE
fix: Improve fcitx5 config item handling

### DIFF
--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.h
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.h
@@ -37,6 +37,7 @@ public Q_SLOTS:
     void save();
     QVariantList globalConfigTypes() const;
     QVariantList globalConfigOptions(const QString &type) const;
+    void restoreDefault(const QString &type);
     void requestConfig(bool sync);
 
 private Q_SLOTS:

--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -37,16 +37,13 @@ DccObject {
                 text: dccObj.displayName
             }
             D.IconButton {
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                Layout.rightMargin: 0
+                Layout.topMargin: (parent.height - height) / 2 - 2
                 icon.width: 12
                 icon.height: 12
                 implicitWidth: 12
                 implicitHeight: 12
-                anchors {
-                    right: parent.right
-                    rightMargin: 0
-                    top: parent.top
-                    topMargin: (parent.height - height) / 2 - 2
-                }
                 icon.name: headerItem.expanded ? "go-down" : "go-next"
                 flat: true
                 onClicked: headerItem.expanded = !headerItem.expanded
@@ -129,12 +126,14 @@ DccObject {
 
                         Component {
                             id: keyComponent
-                            D.KeySequenceEdit {
+                            KeySequenceDisplay {
                                 placeholderText: qsTr("Please enter a new shortcut")
                                 keys: modelData.value
                                 background.visible: false
-                                onKeysChanged: {
-                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name + "/0", keys, true)
+                                onFocusChanged: {
+                                    if (!focus) {
+                                        dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name + "/0", keys, true)
+                                    }
                                 }
                             }
                         }

--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -60,7 +60,7 @@ DccObject {
         dccData.fcitx5ConfigProxy.onRequestConfigFinished.connect(() => {
             configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
         })
-        configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
+        configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name).reverse()
         loading = false
     }
 
@@ -100,7 +100,7 @@ DccObject {
                             D.Switch {
                                 checked: modelData.value === "True"
                                 onCheckedChanged: {
-                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name, checked.toString())
+                                    dccData.fcitx5ConfigProxy.setValue(root.name + "/" + modelData.name, checked ? "True" : "False")
                                 }
                             }
                         }

--- a/src/dcc-fcitx5configtool/qml/KeySequenceDisplay.qml
+++ b/src/dcc-fcitx5configtool/qml/KeySequenceDisplay.qml
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick 2.11
+import QtQuick.Controls
+import QtQuick.Layouts 1.11
+import org.deepin.dtk 1.0 as D
+import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk.private 1.0 as P
+
+Control {
+    id: control
+    property string text
+    property string placeholderText
+    property alias keys: listener.keys
+    property D.Palette backgroundColor: DS.Style.keySequenceEdit.background
+    property D.Palette placeholderTextColor: DS.Style.keySequenceEdit.placeholderText
+
+    background: Rectangle {
+        implicitWidth: DS.Style.keySequenceEdit.width
+        implicitHeight: DS.Style.keySequenceEdit.height
+        radius: DS.Style.control.radius
+        color: control.D.ColorSelector.backgroundColor
+    }
+
+    contentItem: RowLayout {
+        Label {
+            Layout.leftMargin: DS.Style.keySequenceEdit.margin
+            text: control.text
+            horizontalAlignment: Qt.AlignLeft
+            verticalAlignment: Qt.AlignVCenter
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+        }
+
+        Component {
+            id: inputComponent
+            Label {
+                text: control.placeholderText
+                color: control.D.ColorSelector.placeholderTextColor
+                font: D.DTK.fontManager.t7
+                horizontalAlignment: Qt.AlignRight
+                verticalAlignment: Qt.AlignVCenter
+            }
+        }
+
+        Component {
+            id: keyComponent
+            RowLayout {
+                spacing: DS.Style.keySequenceEdit.margin
+                Repeater {
+                    model: control.keys
+                    P.KeySequenceLabel {
+                        Layout.alignment: Qt.AlignRight
+                        text: modelData
+                    }
+                }
+            }
+        }
+
+        Loader {
+            Layout.rightMargin: DS.Style.keySequenceEdit.margin
+            Layout.alignment: Qt.AlignVCenter
+            sourceComponent: (control.keys.length !== 0) ? keyComponent : inputComponent
+
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    control.forceActiveFocus()
+                    listener.clearKeys()
+                }
+            }
+        }
+    }
+    Keys.onReleased: function(event) {
+        if (!event.isAutoRepeat && !(event.modifiers & (Qt.ShiftModifier | Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier))) {
+            control.focus = false
+        }
+    }
+
+    D.KeySequenceListener {
+        id: listener
+        target: control
+    }
+}

--- a/src/dcc-fcitx5configtool/qml/ShortcutsModule.qml
+++ b/src/dcc-fcitx5configtool/qml/ShortcutsModule.qml
@@ -32,6 +32,7 @@ DccObject {
                     normal: D.DTK.makeColor(D.Color.Highlight)
                 }
                 onClicked: {
+                    dccData.fcitx5ConfigProxy.restoreDefault("Hotkey")
                     console.log("Restore Defaults button clicked")
                 }
             }


### PR DESCRIPTION
- Reverse config options order for better display
- Fix boolean value conversion in Switch component
- Add Super/Meta key support in key sequence formatting
- Implement restore defaults functionality for shortcuts
- Replace KeySequenceEdit with custom KeySequenceDisplay
- Fix key sequence value saving logic
- Improve layout of config items using Layout instead of anchors

Log: Improve fcitx5 config item handling