### PR TITLE
chore: update copyright and license headers

### DIFF
--- a/src/dcc-fcitx5configtool/qml/IMList.qml
+++ b/src/dcc-fcitx5configtool/qml/IMList.qml
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.15

--- a/src/dcc-fcitx5configtool/qml/InputMethodsChooser.qml
+++ b/src/dcc-fcitx5configtool/qml/InputMethodsChooser.qml
@@ -1,3 +1,5 @@
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
 import QtQuick.Window

--- a/src/dcc-fcitx5configtool/qml/KeySequenceDisplay.qml
+++ b/src/dcc-fcitx5configtool/qml/KeySequenceDisplay.qml
@@ -1,7 +1,6 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
-//
-// SPDX-License-Identifier: LGPL-3.0-or-later
 
+// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.11
 import QtQuick.Controls
 import QtQuick.Layouts 1.11
@@ -74,8 +73,10 @@ Control {
             }
         }
     }
-    Keys.onReleased: function(event) {
-        if (!event.isAutoRepeat && !(event.modifiers & (Qt.ShiftModifier | Qt.ControlModifier | Qt.AltModifier | Qt.MetaModifier))) {
+    Keys.onReleased: function (event) {
+        if (!event.isAutoRepeat
+                && !(event.modifiers & (Qt.ShiftModifier | Qt.ControlModifier
+                                        | Qt.AltModifier | Qt.MetaModifier))) {
             control.focus = false
         }
     }


### PR DESCRIPTION
1. Update copyright headers to "2024 - 2027 UnionTech Software Technology Co., Ltd."
2. Change license from LGPL-3.0 to GPL-3.0 in QML files
3. Add missing copyright headers to IMList.qml and InputMethodsChooser.qml
4. Fix code formatting in KeySequenceDisplay.qml

This change ensures consistent copyright and license information across QML files in the project.

Log: update copyright