### PR TITLE
fix: remove unsupported input method switch shortcuts

### DIFF
--- a/src/dcc-fcitx5configtool/qml/ShortcutsModule.qml
+++ b/src/dcc-fcitx5configtool/qml/ShortcutsModule.qml
@@ -8,7 +8,7 @@ import org.deepin.dtk 1.0 as D
 import org.deepin.dcc 1.0
 
 DccObject {
-    readonly property var enumKeys: ["None", "CTRL_SHIFT", "ALT_SHIFT", "CTRL_SUPER", "ALT_SUPER"]
+    readonly property var enumKeys: ["None", "CTRL_SHIFT", "ALT_SHIFT"]
     property var triggerKeys: dccData.fcitx5ConfigProxy.globalConfigOption(
                                   "Hotkey", "TriggerKeys")
     property int enumerateForwardKeys: calculateEnumerateForwardKeys(


### PR DESCRIPTION
- Remove CTRL_SUPER and ALT_SUPER from enumKeys as fcitx5 does not support these shortcuts for input method switching

Log:

Bug: https://pms.uniontech.com/bug-view-292717.html