### PR TITLE
fix: update font styling and parent-child relationships in QML files

### DIFF
--- a/src/dcc-fcitx5configtool/qml/AddonsPage.qml
+++ b/src/dcc-fcitx5configtool/qml/AddonsPage.qml
@@ -25,7 +25,11 @@ DccObject {
             Label {
                 Layout.leftMargin: 10
                 Layout.fillWidth: true
-                font: D.DTK.fontManager.t4
+                font {
+                    family: D.DTK.fontManager.t4.family
+                    pixelSize: D.DTK.fontManager.t4.pixelSize
+                    weight: Font.Medium
+                }
                 text: dccObj.displayName
             }
         }

--- a/src/dcc-fcitx5configtool/qml/AdvancedSettingsModule.qml
+++ b/src/dcc-fcitx5configtool/qml/AdvancedSettingsModule.qml
@@ -10,14 +10,18 @@ import org.deepin.dcc 1.0
 DccObject {
     DccObject {
         name: "AdvancedSettingsTitle"
-        parentName: "Manage Input Methods"
+        parentName: "AdvancedSettings"
         displayName: qsTr("Advanced Settings")
         weight: 310
         pageType: DccObject.Item
         page: ColumnLayout {
             Label {
                 Layout.leftMargin: 10
-                font: D.DTK.fontManager.t4
+                font {
+                    family: D.DTK.fontManager.t4.family
+                    pixelSize: D.DTK.fontManager.t4.pixelSize
+                    weight: Font.Medium
+                }
                 text: dccObj.displayName
             }
             Label {
@@ -37,7 +41,7 @@ DccObject {
 
     DccObject {
         name: "GlobalConfigPage"
-        parentName: "Manage Input Methods"
+        parentName: "AdvancedSettings"
         displayName: qsTr("Global Config")
         weight: 320
         page: DccRightView {
@@ -48,7 +52,7 @@ DccObject {
 
     DccObject {
         name: "AddonsPage"
-        parentName: "Manage Input Methods"
+        parentName: "AdvancedSettings"
         displayName: qsTr("Add-ons")
         weight: 330
         page: DccRightView {

--- a/src/dcc-fcitx5configtool/qml/ManageInputMethodsModule.qml
+++ b/src/dcc-fcitx5configtool/qml/ManageInputMethodsModule.qml
@@ -11,7 +11,7 @@ DccObject {
     // title
     DccObject {
         name: "ManageInputMethodsTitle"
-        parentName: "Manage Input Methods"
+        parentName: "ManageInputMethods"
         displayName: qsTr("Input method management")
         weight: 110
         pageType: DccObject.Item
@@ -20,7 +20,11 @@ DccObject {
             Label {
                 Layout.leftMargin: 10
                 Layout.fillWidth: true
-                font: D.DTK.fontManager.t4
+                font {
+                    family: D.DTK.fontManager.t4.family
+                    pixelSize: D.DTK.fontManager.t4.pixelSize
+                    weight: Font.Medium
+                }
                 text: dccObj.displayName
             }
 
@@ -53,7 +57,7 @@ DccObject {
     // list
     DccObject {
         name: "currentIMList"
-        parentName: "Manage Input Methods"
+        parentName: "ManageInputMethods"
         weight: 120
         backgroundType: DccObject.Normal
         pageType: DccObject.Item

--- a/src/dcc-fcitx5configtool/qml/ShortcutsModule.qml
+++ b/src/dcc-fcitx5configtool/qml/ShortcutsModule.qml
@@ -30,14 +30,18 @@ DccObject {
     // title
     DccObject {
         name: "ShortcutsTitle"
-        parentName: "Manage Input Methods"
+        parentName: "Shortcuts"
         displayName: qsTr("Shortcuts")
         weight: 210
         pageType: DccObject.Item
         page: RowLayout {
             Label {
                 Layout.leftMargin: 10
-                font: D.DTK.fontManager.t4
+                font {
+                    family: D.DTK.fontManager.t4.family
+                    pixelSize: D.DTK.fontManager.t4.pixelSize
+                    weight: Font.Medium
+                }
                 text: dccObj.displayName
             }
             D.Button {
@@ -92,7 +96,7 @@ DccObject {
     // Shortcut of scroll IM
     DccObject {
         name: "scrollIM"
-        parentName: "Manage Input Methods"
+        parentName: "Shortcuts"
         weight: 220
         displayName: qsTr("Scroll between input methods")
         backgroundType: DccObject.Normal
@@ -116,14 +120,14 @@ DccObject {
     // Shortcut of turn on or off
     DccObject {
         name: "turnGrouup"
-        parentName: "Manage Input Methods"
+        parentName: "Shortcuts"
         weight: 230
         pageType: DccObject.Item
         page: DccGroupView {}
 
         DccObject {
             name: "shortcutSetting"
-            parentName: "Manage Input Methods/turnGrouup"
+            parentName: "Shortcuts/turnGrouup"
             displayName: qsTr("Turn on or off input methods")
             weight: 231
             pageType: DccObject.Editor
@@ -143,10 +147,12 @@ DccObject {
 
         DccObject {
             name: "shortcutSettingDesc"
-            parentName: "Manage Input Methods/turnGrouup"
+            parentName: "Shortcuts/turnGrouup"
             weight: 232
             pageType: DccObject.Item
             page: Label {
+                topPadding: 5
+                bottomPadding: 5
                 leftPadding: 10
                 rightPadding: 10
                 Layout.fillWidth: true

--- a/src/dcc-fcitx5configtool/qml/main.qml
+++ b/src/dcc-fcitx5configtool/qml/main.qml
@@ -11,8 +11,14 @@ DccObject {
     // Manage input methods
     DccObject {
         name: "ManageInputMethods"
+        parentName: "Manage Input Methods"
         weight: 100
         pageType: DccObject.Item
+        onParentItemChanged: {
+            if (parentItem) {
+                parentItem.bottomPadding = 0
+            }
+        }
         page: DccGroupView {
             spacing: 0
             isGroup: false
@@ -23,8 +29,15 @@ DccObject {
     // Shortcuts
     DccObject {
         name: "Shortcuts"
+        parentName: "Manage Input Methods"
         weight: 200
         pageType: DccObject.Item
+        onParentItemChanged: {
+            if (parentItem) {
+                parentItem.topPadding = 5
+                parentItem.bottomPadding = 0
+            }
+        }
         page: DccGroupView {
             spacing: 0
             isGroup: false
@@ -35,8 +48,14 @@ DccObject {
     // Advanced Settings
     DccObject {
         name: "AdvancedSettings"
+        parentName: "Manage Input Methods"
         weight: 300
         pageType: DccObject.Item
+        onParentItemChanged: {
+            if (parentItem) {
+                parentItem.topPadding = 5
+            }
+        }
         page: DccGroupView {
             spacing: 0
             isGroup: false


### PR DESCRIPTION
- Expand font property to include explicit family, size and weight settings
- Fix parent component names for better hierarchy organization

Log: update font styling and parent-child relationships in QML files
Bug: https://pms.uniontech.com/bug-view-305843.html