### PR TITLE
fix: adjust spacing in DetailAddonsItem layout

### DIFF
--- a/src/dcc-fcitx5configtool/qml/DetailAddonsItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailAddonsItem.qml
@@ -50,7 +50,7 @@ DccObject {
                     }
                     ColumnLayout {
                         Layout.alignment: Qt.AlignLeft
-                        spacing: 0
+                        spacing: 1
                         DccLabel {
                             Layout.fillHeight: false
                             font: D.DTK.fontManager.t6


### PR DESCRIPTION
Adjust the spacing value from 0 to 1 in ColumnLayout to improve visual appearance.

Log: adjust spacing in DetailAddonsItem layout
Bug: https://pms.uniontech.com/zentao/bug-view-298985.html

## Summary by Sourcery

Bug Fixes:
- Adjust spacing in DetailAddonsItem layout to improve visual appearance.