### PR TITLE
chore: bump version to 6.0.6

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-fcitx5configtool-plugin (6.0.6) unstable; urgency=medium
+
+  * bump version to 6.0.6
+  * Merge Qt5 and Qt6 build.
+
+ -- re2zero <yangwu@uniontech.com>  Thu, 27 Mar 2025 13:25:42 +0800
+
 deepin-fcitx5configtool-plugin (6.0.5) unstable; urgency=medium
 
   * fix: adjust spacing between labels in AdvancedSettingsModule


### PR DESCRIPTION
bump version to 6.0.6

Log: bump version to 6.0.6

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect the new version 6.0.6