### PR TITLE
fix: Fix translations for dde control center plugin

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-fcitx5configtool-plugin (6.0.7) unstable; urgency=medium
+
+  * bump version to 6.0.7
+  * Fix translations for dde control center plugin.
+
+ -- re2zero <yangwu@uniontech.com>  Fri, 28 Mar 2025 14:18:19 +0800
+
 deepin-fcitx5configtool-plugin (6.0.6) unstable; urgency=medium
 
   * bump version to 6.0.6

--- a/src/dcc-fcitx5configtool/CMakeLists.txt
+++ b/src/dcc-fcitx5configtool/CMakeLists.txt
@@ -54,4 +54,4 @@ target_link_libraries(${DccFcitx5configtool_Name} PRIVATE
 )
 
 dcc_install_plugin(NAME ${DccFcitx5configtool_Name} TARGET ${DccFcitx5configtool_Name})
-dcc_handle_plugin_translation(NAME ${DccFcitx5configtool_Name} )
+dcc_handle_plugin_translation(NAME ${DccFcitx5configtool_Name})

--- a/src/dcc-fcitx5configtool/translations/fcitx5configtool_en.ts
+++ b/src/dcc-fcitx5configtool/translations/fcitx5configtool_en.ts
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>AddonsPage</name>
+    <message>
+        <location filename="../qml/AddonsPage.qml" line="20"/>
+        <source>Add-ons</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedSettingsModule</name>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="14"/>
+        <source>Advanced Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="28"/>
+        <source>&quot;Advanced Settings&quot; is only valid for the input method that uses the system settings, if the input method has its own settings, its own settings shall prevail.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="41"/>
+        <source>Global Config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="52"/>
+        <source>Add-ons</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DetailConfigItem</name>
+    <message>
+        <location filename="../qml/DetailConfigItem.qml" line="126"/>
+        <source>Please enter a new shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>IMList</name>
+    <message>
+        <location filename="../qml/IMList.qml" line="54"/>
+        <source>Move Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="61"/>
+        <source>Move Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="69"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="76"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InputMethodsChooser</name>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="29"/>
+        <source>Add input method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="37"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="102"/>
+        <source>Find more in App Store</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="121"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="128"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ManageInputMethodsModule</name>
+    <message>
+        <location filename="../qml/ManageInputMethodsModule.qml" line="15"/>
+        <source>Input method management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ManageInputMethodsModule.qml" line="29"/>
+        <source>Add input method</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutsModule</name>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="34"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="45"/>
+        <source>Restore Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="97"/>
+        <source>Scroll between input methods</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="127"/>
+        <source>Turn on or off input methods</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="131"/>
+        <source>Please enter a new shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="156"/>
+        <source>It turns on or off the currently used input method.If no input method is being used or the first input method is not the keyboard, it switches between the first input method and the currently used keyboard/input method.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>fcitx5configtool</name>
+    <message>
+        <location filename="../qml/fcitx5configtool.qml" line="8"/>
+        <source>Input Methods</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/fcitx5configtool.qml" line="9"/>
+        <source>Input method management, input method shortcuts, advanced settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/src/dcc-fcitx5configtool/translations/fcitx5configtool_en_US.ts
+++ b/src/dcc-fcitx5configtool/translations/fcitx5configtool_en_US.ts
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>AddonsPage</name>
+    <message>
+        <location filename="../qml/AddonsPage.qml" line="20"/>
+        <source>Add-ons</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedSettingsModule</name>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="14"/>
+        <source>Advanced Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="28"/>
+        <source>&quot;Advanced Settings&quot; is only valid for the input method that uses the system settings, if the input method has its own settings, its own settings shall prevail.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="41"/>
+        <source>Global Config</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="52"/>
+        <source>Add-ons</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>DetailConfigItem</name>
+    <message>
+        <location filename="../qml/DetailConfigItem.qml" line="126"/>
+        <source>Please enter a new shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>IMList</name>
+    <message>
+        <location filename="../qml/IMList.qml" line="54"/>
+        <source>Move Up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="61"/>
+        <source>Move Down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="69"/>
+        <source>Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="76"/>
+        <source>Remove</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>InputMethodsChooser</name>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="29"/>
+        <source>Add input method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="37"/>
+        <source>Search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="102"/>
+        <source>Find more in App Store</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="121"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="128"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ManageInputMethodsModule</name>
+    <message>
+        <location filename="../qml/ManageInputMethodsModule.qml" line="15"/>
+        <source>Input method management</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ManageInputMethodsModule.qml" line="29"/>
+        <source>Add input method</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutsModule</name>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="34"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="45"/>
+        <source>Restore Defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="97"/>
+        <source>Scroll between input methods</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="127"/>
+        <source>Turn on or off input methods</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="131"/>
+        <source>Please enter a new shortcut</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="156"/>
+        <source>It turns on or off the currently used input method.If no input method is being used or the first input method is not the keyboard, it switches between the first input method and the currently used keyboard/input method.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>fcitx5configtool</name>
+    <message>
+        <location filename="../qml/fcitx5configtool.qml" line="8"/>
+        <source>Input Methods</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/fcitx5configtool.qml" line="9"/>
+        <source>Input method management, input method shortcuts, advanced settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/src/lib/layout/kbd-layout-viewer6.desktop.in
+++ b/src/lib/layout/kbd-layout-viewer6.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Exec=kbd-layout-viewer5
+Exec=kbd-layout-viewer6
 Icon=input-keyboard
 Type=Application
 


### PR DESCRIPTION
Fix translations for dde control center plugin which add en translation files.

Log: Fix translations for dde control center plugin.

## Summary by Sourcery

Documentation:
- Add English (en) and English US (en_US) translation files for the Fcitx5 configuration plugin in the DDE Control Center