### PR TITLE
chore: bump version to 6.0.8

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-fcitx5configtool-plugin (6.0.8) unstable; urgency=medium
+
+  * bump version to 6.0.8.
+  * Add fcitx5-helper executable and desktop entry.
+
+ -- Wang Yu <wangyu@uniontch.com>  Tue, 13 May 2025 15:36:29 +0800
+
 deepin-fcitx5configtool-plugin (6.0.7) unstable; urgency=medium
 
   * bump version to 6.0.7


### PR DESCRIPTION
bump version to 6.0.8

Log: bump version to 6.0.8

## Summary by Sourcery

Chores:
- Update Debian changelog entry to version 6.0.8