### PR TITLE
chore: replace the original icon with the dci icon

### DIFF
--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -57,7 +57,7 @@ DccObject {
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                 icon.width: 12
                 icon.height: 12
-                icon.name: headerItem.expanded ? "go-down" : "go-next"
+                icon.name: headerItem.expanded ? "arrow_ordinary_down" : "arrow_ordinary_right"
                 onClicked: headerItem.expanded = !headerItem.expanded
             }
         }


### PR DESCRIPTION
"arrow_ordinary_down" : "arrow_ordinary_right" from DTK

Log: replace the original icon with the dci icon

## Summary by Sourcery

Chores:
- Replace "go-down"/"go-next" icon names with "arrow_ordinary_down"/"arrow_ordinary_right" for the detail config item