### PR TITLE
chore: bump version to 6.0.12

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-fcitx5configtool-plugin (6.0.12) unstable; urgency=medium
+
+  * fix bugs
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Fri, 27 Jun 2025 17:32:22 +0800
+
 deepin-fcitx5configtool-plugin (6.0.11) unstable; urgency=medium
 
   * chore: update translations (#95)


### PR DESCRIPTION
6.0.12

Log:

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.0.12