### PR TITLE
chore: add translation yaml files to REUSE license configuration

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -34,7 +34,7 @@ Copyright: Deepin Technology Co., Ltd.
 License: GPL-3.0-or-later
 
 # xml yaml toml json conf policy
-Files: *.ui *.qrc *.json *.conf **/config
+Files: *.ui *.qrc *.json *.conf **/config .tx/*.yaml
 Copyright: None
 License: CC0-1.0
 


### PR DESCRIPTION
- Added .tx/*.yaml to CC0-1.0 license coverage in dep5 file.

Log: add translation yaml files to REUSE license configuration

## Summary by Sourcery

Chores:
- Include .tx/*.yaml files in CC0-1.0 license coverage in dep5 configuration