### PR TITLE
fix: improve C++ standard compliance and debug logging

### DIFF
--- a/src/fcitx5helper/CMakeLists.txt
+++ b/src/fcitx5helper/CMakeLists.txt
@@ -11,7 +11,7 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Wall -Wextra")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Wextra -pthread")
   # Enable Qt builtin debug mode
-  add_definitions("-DQT_MESSAGELOGCONTEXT -std=c++11")
+  add_definitions("-DQT_MESSAGELOGCONTEXT")
 else()
   # -Wl, -O2 Enable linker optimizations
   # -Wl, --gc-sections Remove unused code resulting from -fdsta-sections and

--- a/src/fcitx5helper/processmonitor.cpp
+++ b/src/fcitx5helper/processmonitor.cpp
@@ -19,7 +19,7 @@ static QString getCurrentUserName() {
 
 
 bool ProcessMonitor::exeCommand(const QString &cmd, const QStringList &args, QString &output, QString &err) {
-    qDebug() << "Executing command:" << cmd << args;
+    qDebug() << "Executing command:" << cmd << args.join(" ");
     QProcess process;
     process.setProgram(cmd);
     process.setArguments(args);
@@ -31,7 +31,7 @@ bool ProcessMonitor::exeCommand(const QString &cmd, const QStringList &args, QSt
 
     bool success = (process.exitStatus() == QProcess::NormalExit && process.exitCode() == 0);
     if (!success) {
-        qWarning() << "Command failed:" << cmd << args << "Error:" << err;
+        qWarning() << "Command failed:" << cmd << args.join(" ") << "Error:" << err;
     }
     qDebug() << "Command execution result:" << success;
     return success;

--- a/src/fcitx5helper/processmonitor.h
+++ b/src/fcitx5helper/processmonitor.h
@@ -17,11 +17,12 @@ public:
 
     static bool exeCommand(const QString &cmd, const QStringList &args, QString &output, QString &err);
 
+private Q_SLOTS:
+    void checkFcitx5Process();
+
 private:
     QTimer m_timer;
     QString m_previousProcessID;
-
-    void checkFcitx5Process();
 };
 
 #endif // PROCESSMONITOR_H


### PR DESCRIPTION
- Remove explicit C++11 standard flag to use project default (C++17)
- Enhance command logging readability by joining arguments with spaces
- Move checkFcitx5Process to private slots section for proper Qt organization

Log: improve C++ standard compliance and debug logging