### PR TITLE
chore: Add new Lao translation file

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-fcitx5configtool-plugin (6.0.15) unstable; urgency=medium
+
+  * chore: Add new Lao translation file
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 07 Aug 2025 17:47:09 +0800
+
 deepin-fcitx5configtool-plugin (6.0.14) unstable; urgency=medium
 
   * add single instance lock mechanism for fcitx5-helper

--- a/src-old/src/dcc-module/translations/deepin-fcitx5configtool-plugin_lo.ts
+++ b/src-old/src/dcc-module/translations/deepin-fcitx5configtool-plugin_lo.ts
@@ -3,75 +3,75 @@
     <name>AddIMPage</name>
     <message>
         <source>Select your language and add input methods</source>
-        <translation type="unfinished"/>
+        <translation>ເລືອກພາສາຂອງທ່ານ ແລະ ເພີ່ມວິທີການປ້ອນຂໍ້ມູນ</translation>
     </message>
     <message>
         <source>Find more in App Store</source>
-        <translation type="unfinished"/>
+        <translation>ຊອກຫາເພີ່ມເຕີມໃນຮ້ານອັບ</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation>ຍົກເລີກ</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation>ເພີ່ມ</translation>
     </message>
 </context>
 <context>
     <name>Fcitx5ConfigPlugin</name>
     <message>
         <source>deepin-fcitx5configtool-plugin</source>
-        <translation type="unfinished"/>
+        <translation>ສ່ວນເຕີມສຳລັບການຈັດການວິທີການປ້ອນຂໍ້ມູນ</translation>
     </message>
     <message>
         <source>Input Method</source>
-        <translation type="unfinished"/>
+        <translation>ວິທີການປ້ອນຂໍ້ມູນ</translation>
     </message>
 </context>
 <context>
     <name>IMSettingWindow</name>
     <message>
         <source>Manage Input Methods</source>
-        <translation type="unfinished"/>
+        <translation>ຈັດການວິທີການປ້ອນຂໍ້ມູນ</translation>
     </message>
     <message>
         <source>Shortcuts</source>
-        <translation type="unfinished"/>
+        <translation>ສັງລວມ</translation>
     </message>
     <message>
         <source>Restore Defaults</source>
-        <translation type="unfinished"/>
+        <translation>ກັບຄືນຄ່າເລີ່ມຕົ້ນ</translation>
     </message>
     <message>
         <source>Scroll between input methods</source>
-        <translation type="unfinished"/>
+        <translation>ລໍ້ນ້ອຍລະຫວ່າງວິທີການປ້ອນຂໍ້ມູນ</translation>
     </message>
     <message>
         <source>Switch between the current/first input method</source>
-        <translation type="unfinished"/>
+        <translation>ສະແດງລະຫວ່າງວິທີການປ້ອນຂໍ້ມູນປັດຈຸບັນ/ວິທີການປ້ອນຂໍ້ມູນອັນດັບທຳອິດ</translation>
     </message>
     <message>
         <source>Advanced Settings</source>
-        <translation type="unfinished"/>
+        <translation>ການຕັ້ງຄ່າຂັ້ນສູງ</translation>
     </message>
 </context>
 <context>
     <name>LayoutWidget</name>
     <message>
         <source>The current input method has no keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation>ວິທີການປ້ອນຂໍ້ມູນປັດຈຸບັນບໍ່ມີການຈັດຮູບແບບກີບ</translation>
     </message>
     <message>
         <source>Multiple input methods have been selected</source>
-        <translation type="unfinished"/>
+        <translation>ມີການປ້ອນຂໍ້ມູນຫຼາຍຢ່າງທີ່ຖືກເລືອກ</translation>
     </message>
 </context>
 <context>
     <name>dcc_fcitx_configtool::widgets::FcitxKeyLabelWidget</name>
     <message>
         <source>Enter a new shortcut</source>
-        <translation type="unfinished"/>
+        <translation>ປ້ອນສັ້ນໆໃໝ່</translation>
     </message>
 </context>
 </TS>

--- a/src/dcc-fcitx5configtool/translations/fcitx5configtool_lo.ts
+++ b/src/dcc-fcitx5configtool/translations/fcitx5configtool_lo.ts
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>AddonsPage</name>
+    <message>
+        <location filename="../qml/AddonsPage.qml" line="20"/>
+        <source>Add-ons</source>
+        <translation>ສ່ວນເຕີມ</translation>
+    </message>
+</context>
+<context>
+    <name>AdvancedSettingsModule</name>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="14"/>
+        <source>Advanced Settings</source>
+        <translation>ການຕັ້ງຄ່າຂັ້ນສູງ</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="28"/>
+        <source>&quot;Advanced Settings&quot; is only valid for the input method that uses the system settings, if the input method has its own settings, its own settings shall prevail.</source>
+        <translation>&quot;ການຕັ້ງຄ່າຂັ້ນສູງ&quot; ໃຊ້ງານໄດ້ສຳລັບວິທີປ້ອນຂໍ້ມູນທີ່ໃຊ້ການຕັ້ງຄ່າລະບົບເທົ່ານັ້ນ, ຖ້າວິທີປ້ອນຂໍ້ມູນມີການຕັ້ງຄ່າຂອງຕົນເອງ, ການຕັ້ງຄ່າຂອງຕົນເອງຈະຖືກນຳໃຊ້ເປັນຫຼັກ.</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="41"/>
+        <source>Global Config</source>
+        <translation>ການຕັ້ງຄ່າທົ່ວໄປ</translation>
+    </message>
+    <message>
+        <location filename="../qml/AdvancedSettingsModule.qml" line="52"/>
+        <source>Add-ons</source>
+        <translation>ສ່ວນເຕີມ</translation>
+    </message>
+</context>
+<context>
+    <name>DetailConfigItem</name>
+    <message>
+        <location filename="../qml/DetailConfigItem.qml" line="126"/>
+        <source>Please enter a new shortcut</source>
+        <translation>ກະລຸນາປ້ອນສັງລວມທີ່ໃຫມ່</translation>
+    </message>
+</context>
+<context>
+    <name>IMList</name>
+    <message>
+        <location filename="../qml/IMList.qml" line="54"/>
+        <source>Move Up</source>
+        <translation>ເຄື່ອນໄຫວຂຶ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="61"/>
+        <source>Move Down</source>
+        <translation>ເຄື່ອນໄຫວລົງ</translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="69"/>
+        <source>Settings</source>
+        <translation>ການຕັ້ງຄ່າ</translation>
+    </message>
+    <message>
+        <location filename="../qml/IMList.qml" line="76"/>
+        <source>Remove</source>
+        <translation>ລຶບ</translation>
+    </message>
+</context>
+<context>
+    <name>InputMethodsChooser</name>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="29"/>
+        <source>Add input method</source>
+        <translation>ເພີ່ມວິທີການປ້ອນຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="37"/>
+        <source>Search</source>
+        <translation>ຄົ້ນຫາ</translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="102"/>
+        <source>Find more in App Store</source>
+        <translation>ຄົ້ນຫາມາກຂຶ້ນໃນໂຮງຂາງການຊື້ຂາຍ</translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="121"/>
+        <source>Cancel</source>
+        <translation>ຢກເລີກ</translation>
+    </message>
+    <message>
+        <location filename="../qml/InputMethodsChooser.qml" line="128"/>
+        <source>Add</source>
+        <translation>ເພີ່ມ</translation>
+    </message>
+</context>
+<context>
+    <name>ManageInputMethodsModule</name>
+    <message>
+        <location filename="../qml/ManageInputMethodsModule.qml" line="15"/>
+        <source>Input method management</source>
+        <translation>ການຈັດການວິທີການປ້ອນຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../qml/ManageInputMethodsModule.qml" line="29"/>
+        <source>Add input method</source>
+        <translation>ເພີ່ມວິທີການປ້ອນຂໍ້ມູນ</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutsModule</name>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="34"/>
+        <source>Shortcuts</source>
+        <translation>ສັງລວມ</translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="45"/>
+        <source>Restore Defaults</source>
+        <translation>ກັ່ນຕອງຄ່າເລີ່ມຕົ້ນ</translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="97"/>
+        <source>Scroll between input methods</source>
+        <translation>ເຄື່ອນໄຫວລະຫວ່າງວິທີການປ້ອນຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="127"/>
+        <source>Turn on or off input methods</source>
+        <translation>ເປີດ ຫຼື ອອກວິທີການປ້ອນຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="131"/>
+        <source>Please enter a new shortcut</source>
+        <translation>ກະລຸນາປ້ອນສັງລວມທີ່ໃຫມ່</translation>
+    </message>
+    <message>
+        <location filename="../qml/ShortcutsModule.qml" line="156"/>
+        <source>It turns on or off the currently used input method.If no input method is being used or the first input method is not the keyboard, it switches between the first input method and the currently used keyboard/input method.</source>
+        <translation>ມັນຈະເປີດ ຫຼື ປິດວິທີການປ້ອນຂໍ້ມູນທີ່ກຳລັງໃຊ້ຢູ່. ຖ້າບໍ່ມີວິທີການປ້ອນຂໍ້ມູນຖືກໃຊ້ ຫຼື ວິທີການປ້ອນຂໍ້ມູນອັນດັບທຳອິດບໍ່ແມ່ນແປ້ນພິມ, ມັນຈະສະຫຼັບລະຫວ່າງວິທີການປ້ອນຂໍ້ມູນອັນດັບທຳອິດ ແລະ ແປ້ນພິມ/ວິທີການປ້ອນຂໍ້ມູນທີ່ກຳລັງໃຊ້ຢູ່.</translation>
+    </message>
+</context>
+<context>
+    <name>fcitx5configtool</name>
+    <message>
+        <location filename="../qml/fcitx5configtool.qml" line="8"/>
+        <source>Input Methods</source>
+        <translation>ວິທີການປ້ອນຂໍ້ມູນ</translation>
+    </message>
+    <message>
+        <location filename="../qml/fcitx5configtool.qml" line="9"/>
+        <source>Input method management, input method shortcuts, advanced settings</source>
+        <translation>ການຈັດການວິທີການປ້ອນຂໍ້ມູນ, ວິທີການປ້ອນຂໍ້ມູນເວົ້າສັ້ນ, ວາລະສານຂັ້ນສູງ</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
chore: Add new Lao translation file
    
- Add new Lao translation file
    
Log: Improve language support by adding Lao translation

## Summary by Sourcery

Add Lao language support by introducing a new Lao translation file for the fcitx5 configuration tool and completing existing Lao translations in the legacy plugin file.

Chores:
- Add new Lao translation file for the dcc-fcitx5configtool UI
- Replace unfinished placeholders with Lao translations in the legacy deepin-fcitx5configtool-plugin file