### PR TITLE
fix: resolve naming conflicts and add loading state in QML components

### DIFF
--- a/src/dcc-fcitx5configtool/qml/DetailAddonsItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailAddonsItem.qml
@@ -11,6 +11,7 @@ import org.deepin.dcc 1.0
 DccObject {
     id: root
     property var globalAddons: []
+    property bool loading: true
 
     Component.onCompleted: {
         dccData.fcitx5AddonsProxy.onRequestAddonsFinished.connect(() => {

--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -12,9 +12,10 @@ DccObject {
     id: root
     property var configOptions: []
     property var keyName: ""
+    property bool loading: true
 
     DccObject {
-        name: root.displayName
+        name: root.displayName + "_Container"  // Add suffix to avoid conflict with root.name
         parentName: "GlobalConfigPage"
         weight: 40
         pageType: DccObject.Item
@@ -33,7 +34,7 @@ DccObject {
     DccObject {
         id: headerItem
         property bool expanded: false
-        parentName: root.displayName
+        parentName: root.displayName + "_Container"  // Update to match the new name above
         displayName: root.displayName
         weight: root.weight
         pageType: DccObject.Item
@@ -81,7 +82,7 @@ DccObject {
             model: configOptions
             delegate: Component {
                 DccObject {
-                    parentName: root.displayName
+                    parentName: root.displayName + "_Container"  // Update to match the new name above
                     displayName: modelData.description
                     weight: root.weight + index + 1
                     pageType: DccObject.Editor


### PR DESCRIPTION
- Added loading property to DetailAddonsItem and DetailConfigItem
- Fixed parent name conflicts by adding "_Container" suffix
- Updated all parentName references to use consistent naming convention

Log: resolve naming conflicts and add loading state in QML components
pms: BUG-324491

## Summary by Sourcery

Add loading state support and fix naming conflicts in QML components for config and addons details

New Features:
- Add loading property to DetailAddonsItem and DetailConfigItem QML components

Bug Fixes:
- Resolve parent name conflicts by appending "_Container" suffix and updating parentName references accordingly