### PR TITLE
chore: Update version to 6.0.29

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-fcitx5configtool-plugin (6.0.29) unstable; urgency=medium
+
+  * fix(addonUi): simplify DetailAddonsItem structure by removing Loader component
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Wed, 01 Apr 2026 09:52:21 +0800
+
 deepin-fcitx5configtool-plugin (6.0.28) unstable; urgency=medium
 
   * fix: add UOS build support and update dependencies


### PR DESCRIPTION
- update version to 6.0.29

log: update version to 6.0.29

## Summary by Sourcery

Chores:
- Update Debian changelog entry to version 6.0.29.