### PR TITLE
chore: update version to 6.0.30

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-fcitx5configtool-plugin (6.0.30) unstable; urgency=medium
+
+  * fix: support dual key bindings for Ctrl+Shift layout switching
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 17 Apr 2026 09:22:30 +0800
+
 deepin-fcitx5configtool-plugin (6.0.29) unstable; urgency=medium
 
   * fix(addonUi): simplify DetailAddonsItem structure by removing Loader component


### PR DESCRIPTION
- bump version to 6.0.30

Log : bump version to 6.0.30

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.0.30.