### PR TITLE
fix: use dynamic integer range from fcitx5 config properties

### DIFF
--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -218,6 +218,13 @@ QVariantList Fcitx5ConfigProxy::globalConfigOptions(const QString &type, bool al
                         break;
                     }
                     ++iterator;
+                }
+                if (option.type() == "Integer") {
+                    bool ok = false;
+                    int maxVal = properties.contains("IntMax") ? properties["IntMax"].toInt(&ok) : 9999;
+                    item["intMax"] = ok ? maxVal : 9999;
+                    int minVal = properties.contains("IntMin") ? properties["IntMin"].toInt(&ok) : 0;
+                    item["intMin"] = ok ? minVal : 0;
                 }
             }
             list.append(item);

--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -112,8 +112,11 @@ DccObject {
                         Component {
                             id: integerComponent
                             D.SpinBox {
-                                width: 55
-                                implicitWidth: 55
+                                editable: true
+                                width: 75
+                                implicitWidth: 75
+                                from: modelData.intMin !== undefined ? modelData.intMin : 0
+                                to: modelData.intMax !== undefined ? modelData.intMax : 9999
                                 value: parseInt(modelData.value)
                                 onValueChanged: {
                                     dccData.fcitx5ConfigProxy.setValue(


### PR DESCRIPTION
Pass IntMax/IntMin properties for Integer type options to QML SpinBox, enable editable input and set fixed width to prevent layout stretching.

将Integer类型选项的IntMax/IntMin属性传递到QML SpinBox，启用可编辑输入并设置固定宽度防止布局拉伸。

Log: SpinBox支持动态整数范围和可编辑输入
PMS: BUG-357563
Influence: Integer类型配置项的SpinBox现在使用fcitx5配置中定义的实际范围，支持手动输入数值。

## Summary by Sourcery

Use fcitx5 Integer option metadata to define dynamic ranges for SpinBox-based integer configuration entries and allow direct value editing in the config UI.

New Features:
- Support dynamic integer min/max ranges on SpinBox controls based on fcitx5 IntMin/IntMax properties.
- Enable editable text input for integer SpinBox configuration fields.

Bug Fixes:
- Ensure integer configuration SpinBoxes respect the actual fcitx5-defined bounds instead of using hardcoded defaults.

Enhancements:
- Adjust SpinBox width to a fixed larger size to avoid layout stretching while accommodating editable input.