### PR TITLE
fix: prevent crash from RequestConfigFinished signal connection

### DIFF
--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -190,14 +190,16 @@ DccObject {
             }
         }
     }
+    Connections {
+        target: dccData.fcitx5ConfigProxy
+        function onRequestConfigFinished() {
+            configOptions = []
+            configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
+            keyName = ""
+        }
+    }
 
     Component.onCompleted: {
-        dccData.fcitx5ConfigProxy.onRequestConfigFinished.connect(() => {
-                                                                      configOptions = []
-                                                                      configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(
-                                                                          root.name)
-                                                                      keyName = ""
-                                                                  })
         configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
         loading = false
     }


### PR DESCRIPTION
Changed the signal connection from lambda in Component.onCompleted to proper Connections component. The previous approach using a lambda directly connected to the signal could cause crashes when the component was destroyed, as the lambda might outlive the QML context or create dangling references. Using the Connections component ensures proper lifecycle management and automatic disconnection when the component is destroyed.

Influence:
1. Test opening and closing detail configuration pages multiple times
2. Verify no crash occurs when rapidly switching between different configuration items
3. Test memory stability during extended usage of the configuration tool
4. Verify signal disconnection works correctly when components are destroyed
5. Test that globalConfigOptions are properly refreshed when RequestConfigFinished is emitted

fix: 修复 RequestConfigFinished 信号导致崩溃的问题

将信号连接方式从 Component.onCompleted 中的 lambda 改为使用 Connections 组件。之前直接在信号上连接 lambda 的方式可能在组件销毁时导致崩溃，因为
lambda 可能超出 QML 上下文的生命周期或产生悬空引用。使用 Connections 组
件可以确保正确的生命周期管理，并在组件销毁时自动断开连接。

Influence:
1. 测试多次打开和关闭详细配置页面
2. 验证在不同配置项之间快速切换时不会发生崩溃
3. 测试配置工具长时间使用时的内存稳定性
4. 验证组件销毁时信号断开连接是否正常工作
5. 测试 RequestConfigFinished 发出时 globalConfigOptions 是否正确刷新

## Summary by Sourcery

Prevent configuration detail view crashes by changing how the RequestConfigFinished signal is handled in the QML detail config item.

Bug Fixes:
- Use a QML Connections handler for RequestConfigFinished to avoid crashes caused by a lambda tied to the component lifecycle in Component.onCompleted.

Enhancements:
- Ensure configuration options and key name are safely reset and refreshed when RequestConfigFinished is emitted while preserving the initial configuration load on component completion.