### PR TITLE
fix(keyboard): resolve layout name disappearing after deletion

### DIFF
--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.cpp
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -492,23 +492,47 @@ void KeyboardWorker::onLocalListsFinished(QDBusPendingCallWatcher *watch)
 
 void KeyboardWorker::onUserLayout(const QStringList &list)
 {
-    m_model->cleanUserLayout();
     m_model->getUserLayoutList() = list;
+    m_pendingLayouts.clear();
+    m_pendingLayoutCount = list.size();
+    m_batchId++;
+
+    if (list.isEmpty()) {
+        m_model->cleanUserLayout();
+        return;
+    }
 
     for (const QString &data : list) {
         QDBusPendingCallWatcher *layoutResult = new QDBusPendingCallWatcher(m_keyboardDBusProxy->GetLayoutDesc(data), this);
         layoutResult->setProperty("id", data);
+        layoutResult->setProperty("batchId", m_batchId);
         connect(layoutResult, &QDBusPendingCallWatcher::finished, this, &KeyboardWorker::onUserLayoutFinished);
     }
 }
 
 void KeyboardWorker::onUserLayoutFinished(QDBusPendingCallWatcher *watch)
 {
-    QDBusPendingReply<QString> reply = *watch;
+    if (watch->property("batchId").toULongLong() != m_batchId) {
+        watch->deleteLater();
+        return;
+    }
 
-    m_model->addUserLayout(watch->property("id").toString(), reply.value());
+    QDBusPendingReply<QString> reply = *watch;
+    if (!reply.isError()) {
+        m_pendingLayouts.insert(watch->property("id").toString(), reply.value());
+    } else {
+        qWarning() << "GetLayoutDesc failed for" << watch->property("id").toString()
+                   << ":" << reply.error().message();
+    }
 
     watch->deleteLater();
+
+    if (--m_pendingLayoutCount == 0) {
+        m_model->cleanUserLayout();
+        for (auto it = m_pendingLayouts.constBegin(); it != m_pendingLayouts.constEnd(); ++it) {
+            m_model->addUserLayout(it.key(), it.value());
+        }
+    }
 }
 
 void KeyboardWorker::onCurrentLayout(const QString &value)

--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.h
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -121,6 +121,9 @@ private:
     KeyboardDBusProxy *m_keyboardDBusProxy;
     ShortcutModel *m_shortcutModel = nullptr;
     QTranslator *m_translatorLanguage;
+    QMap<QString, QString> m_pendingLayouts;
+    int m_pendingLayoutCount = 0;
+    quint64 m_batchId = 0;
     Dtk::Core::DConfig *m_inputDevCfg;
 };
 }

--- a/src/dcc-fcitx5configtool/qml/KeyboardLayoutModule.qml
+++ b/src/dcc-fcitx5configtool/qml/KeyboardLayoutModule.qml
@@ -25,7 +25,7 @@ DccObject {
             D.Button {
                 id: button
                 checkable: true
-                visible: dccData.keyboardController.layoutCount > 1
+                visible: dccData.keyboardController.layoutCount > 1 || keyboardLayoutTitle.isEditing
                 checked: keyboardLayoutTitle.isEditing
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                 Layout.rightMargin: 10


### PR DESCRIPTION
Batch collect layout descriptions before updating model to avoid transient empty state during async DBus calls.

批量收集布局描述后再更新模型，避免异步DBus调用期间的空状态。

Also show done button when in editing mode to prevent user getting stuck.

同时修复编辑模式下完成按钮消失的问题。

Log: 修复删除键盘布局后名称消失及完成按钮不显示的问题
PMS: BUG-356121
Influence: 键盘布局编辑功能现在正常工作，删除布局后名称正确显示，编辑模式下始终可以退出编辑。