### PR TITLE
chore: remove unused capsLock/numLock code and fix DTK6 build error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/*
 *.orig
 *~
 .*
+AGENTS.md

--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.cpp
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.cpp
@@ -44,8 +44,6 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Deleted, this, &KeyboardWorker::removed);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::UserLayoutListChanged, this, &KeyboardWorker::onUserLayout);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::CurrentLayoutChanged, this, &KeyboardWorker::onCurrentLayout);
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::CapslockToggleChanged, m_model, &KeyboardModel::setCapsLock);
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::NumLockStateChanged, m_model, &KeyboardModel::setNumLock);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::langSelectorServiceStartFinished, this, [=] {
         QTimer::singleShot(100, this, &KeyboardWorker::onLangSelectorServiceFinished);
     });
@@ -128,9 +126,6 @@ void KeyboardWorker::active()
 
     Q_EMIT onDatasChanged(m_metaDatas);
     Q_EMIT onLettersChanged(m_letters);
-
-    m_model->setCapsLock(m_keyboardDBusProxy->capslockToggle());
-    m_model->setNumLock(m_keyboardDBusProxy->numLockState());
 
     onRefreshKBLayout();
     refreshLang();

--- a/src/dcc-fcitx5configtool/operation/fcitx5configtool.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configtool.cpp
@@ -222,7 +222,7 @@ void Fcitx5ConfigToolWorker::openDeepinAppStore() const
     qCInfo(configTool) << "Request to open Deepin App Store.";
     DDBusSender()
             .service("org.desktopspec.ApplicationManager1")
-            .path(QStringLiteral("/org/desktopspec/ApplicationManager1/") + DUtil::escapeToObjectPath("deepin-app-store"))
+            .path(QStringLiteral("/org/desktopspec/ApplicationManager1/") + DUtil::escapeToObjectPath(QStringLiteral("deepin-app-store")))
             .interface("org.desktopspec.ApplicationManager1.Application")
             .method("Launch")
             .arg(QString(""))


### PR DESCRIPTION
Remove unused CapsLock/NumLock signal connections and initialization in KeyboardWorker, which are already handled by DCC keyboard plugin.

Fix ambiguous overload error for DUtil::escapeToObjectPath() with DTK6 by wrapping string literal in QStringLiteral.

移除 KeyboardWorker 中未使用的 CapsLock/NumLock 信号连接和初始化， 该功能由 DCC 键盘主模块处理。修复 DTK6 下 DUtil::escapeToObjectPath() 重载歧义编译错误。

Log: 清理冗余代码并修复DTK6编译错误
PMS: TASK-390511
Influence: 清理对本项目无影响的死代码，修复DTK6编译兼容性问题。