### PR TITLE
chore: update version to 6.0.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+deepin-fcitx5configtool-plugin (6.0.34) unstable; urgency=medium
+
+  * chore: remove unused capsLock/numLock code and fix DTK6 build error
+  * [skip CI] Translate fcitx5configtool_en.ts in pt_BR
+
+ -- Wang Yu <wangyu@uniontech.com>  Fri, 05 Jun 2026 14:16:16 +0800
+
 deepin-fcitx5configtool-plugin (6.0.33) unstable; urgency=medium
 
   * fix(keyboard): resolve layout name disappearing after deletion


### PR DESCRIPTION
- bump version to 6.0.34

Log : bump version to 6.0.34

## Summary by Sourcery

Build:
- Update Debian packaging metadata to version 6.0.34.