### PR TITLE
chore(keyboard): remove unused windowSwitch and onGetWindowWM dead code

### DIFF
--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.cpp
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.cpp
@@ -39,7 +39,6 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
     , m_translatorLanguage(nullptr)
     , m_inputDevCfg(DConfig::create("org.deepin.dde.daemon", "org.deepin.dde.daemon.inputdevices", QString(), this))
 {
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Added, this, &KeyboardWorker::onAdded);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Deleted, this, &KeyboardWorker::removed);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::UserLayoutListChanged, this, &KeyboardWorker::onUserLayout);
@@ -71,10 +70,6 @@ void KeyboardWorker::resetAll() {
     });
 }
 
-void KeyboardWorker::onGetWindowWM(bool)
-{
-    windowSwitch();
-}
 
 void KeyboardWorker::setShortcutModel(ShortcutModel *model)
 {
@@ -99,21 +94,6 @@ void KeyboardWorker::refreshLang()
         onLangSelectorServiceFinished();
 }
 
-void KeyboardWorker::windowSwitch()
-{
-    QDBusInterface licenseInfo("com.deepin.wm",
-                               "/com/deepin/wm",
-                               "com.deepin.wm",
-                               QDBusConnection::sessionBus());
-    if (!licenseInfo.isValid()) {
-        qDebug() << "com.deepin.license error ," << licenseInfo.lastError().name();
-        return;
-    }
-
-    if (m_shortcutModel)
-        m_shortcutModel->onWindowSwitchChanged(licenseInfo.property("compositingEnabled").toBool());
-}
-
 void KeyboardWorker::active()
 {
     m_keyboardDBusProxy->blockSignals(false);
@@ -129,7 +109,6 @@ void KeyboardWorker::active()
 
     onRefreshKBLayout();
     refreshLang();
-    windowSwitch();
     refreshShortcut();
     if (m_inputDevCfg->isValid()) {
         QMetaObject::invokeMethod(m_model, "setKeyboardEnabled", Qt::DirectConnection, Q_ARG(bool, m_inputDevCfg->value("keyboardEnabled", true).toBool()));

--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.h
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardwork.h
@@ -35,7 +35,6 @@ public:
     void setShortcutModel(ShortcutModel * model);
     void refreshShortcut();
     void refreshLang();
-    void windowSwitch();
 
     inline QList<MetaData> getDatas() {return m_metaDatas;}
     inline QList<QString> getLetters() {return m_letters;}
@@ -84,7 +83,6 @@ public Q_SLOTS:
     void onDisableShortcut(ShortcutInfo* info);
     void onAddedFinished(QDBusPendingCallWatcher *watch);
     void onLocalListsFinished(QDBusPendingCallWatcher *watch);
-    void onGetWindowWM(bool value);
     void onLayoutListsFinished(QDBusPendingCallWatcher *watch);
     void onAllLayoutListsFinished(QDBusPendingCallWatcher *watch);
     void onUserLayout(const QStringList &list);


### PR DESCRIPTION
Remove windowSwitch(), onGetWindowWM() and compositingEnabledChanged signal connection. These are leftover from old dcc-keyboard system shortcut management and have no UI consumer in the fcitx5 plugin.

移除 windowSwitch()、onGetWindowWM() 及 compositingEnabledChanged 信号连接，这些是旧版 dcc-keyboard 系统快捷键管理的遗留代码，
在 fcitx5 插件中无 UI 消费者。

Log: 移除无用的 windowSwitch 相关死代码
PMS: TASK-390511
Influence: 无功能影响，仅移除不被任何 UI 使用的死代码路径。