### PR TITLE
fix(global-config): resolve page jump after save button click

### DIFF
--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
@@ -68,7 +68,7 @@ QStringList Fcitx5ConfigProxyPrivate::formatKey(const QString &shortcut) {
 
 QString Fcitx5ConfigProxyPrivate::formatKeys(const QStringList &keys) {
     qCDebug(proxy) << "Formatting keys from list:" << keys;
-    QStringList list;   
+    QStringList list;
     for (const auto &key : keys) {
         if (key.trimmed().toLower() == "ctrl")
             list << "Control";
@@ -97,14 +97,14 @@ QVariant Fcitx5ConfigProxyPrivate::readDBusValue(const QVariant &value) {
         auto argument = qvariant_cast<QDBusArgument>(value);
         QVariantMap map;
         argument >> map;
-        
+
         QVariantMap resultMap;
         for (auto iter = map.begin(); iter != map.end(); ++iter) {
             resultMap[iter.key()] = readDBusValue(iter.value());
         }
         return resultMap;
     }
-    
+
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     if (value.typeId() == QMetaType::QVariantMap) {
 #else
@@ -117,8 +117,13 @@ QVariant Fcitx5ConfigProxyPrivate::readDBusValue(const QVariant &value) {
         }
         return resultMap;
     }
-    
+
     return value;
+}
+
+bool Fcitx5ConfigProxy::saveTriggered() const
+{
+    return m_saveTriggered;
 }
 
 Fcitx5ConfigProxy::Fcitx5ConfigProxy(fcitx::kcm::DBusProvider *dbus, const QString &path, QObject *parent)
@@ -321,15 +326,18 @@ void Fcitx5ConfigProxy::restoreDefault(const QString &type)
     qCDebug(proxy) << "Exiting restoreDefault";
 }
 
-void Fcitx5ConfigProxy::requestConfig(bool sync)
+void Fcitx5ConfigProxy::requestConfig(bool sync, bool fromSave)
 {
-    qCDebug(proxy) << "Entering requestConfig for path" << d->path << "with sync" << sync;
+    qCDebug(proxy) << "Entering requestConfig for path" << d->path << "with sync" << sync << "fromSave" << fromSave;
     if (!d->dbusprovider->controller()) {
         qCWarning(proxy) << "DBus controller not available for requestConfig";
         return;
     }
     auto call = d->dbusprovider->controller()->GetConfig(d->path);
     auto watcher = new QDBusPendingCallWatcher(call, this);
+    if (fromSave) {
+        watcher->setProperty("saveTriggered", true);
+    }
     connect(watcher,
             &QDBusPendingCallWatcher::finished,
             this,
@@ -340,7 +348,7 @@ void Fcitx5ConfigProxy::requestConfig(bool sync)
     }
     qCDebug(proxy) << "Exiting requestConfig";
 }
- 
+
 void Fcitx5ConfigProxy::onRequestConfigFinished(QDBusPendingCallWatcher *watcher)
 {
     qCDebug(proxy) << "Entering onRequestConfigFinished for path" << d->path;
@@ -351,14 +359,23 @@ void Fcitx5ConfigProxy::onRequestConfigFinished(QDBusPendingCallWatcher *watcher
         return;
     }
     qCInfo(proxy) << "Successfully received config for path:" << d->path;
-    d->configTypes = reply.argumentAt<1>(); 
+    d->configTypes = reply.argumentAt<1>();
 
     auto value = reply.argumentAt<0>().variant();
     QVariantMap allMap;
     allMap = d->readDBusValue(value).toMap();
     std::swap(d->configValue, allMap);
 
+    bool wasSaveTriggered = watcher->property("saveTriggered").toBool();
+    if (wasSaveTriggered) {
+        m_saveTriggered = true;
+        Q_EMIT saveTriggeredChanged();
+    }
     Q_EMIT requestConfigFinished();
+    if (wasSaveTriggered) {
+        m_saveTriggered = false;
+        Q_EMIT saveTriggeredChanged();
+    }
     qCDebug(proxy) << "Exiting onRequestConfigFinished";
 }
 
@@ -397,6 +414,6 @@ void Fcitx5ConfigProxy::save()
 
     QDBusVariant var(d->configValue);
     d->dbusprovider->controller()->SetConfig(d->path, var);
-    requestConfig(false);
+    requestConfig(false, true);
     qCDebug(proxy) << "Exiting save";
 }

--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.h
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,7 @@ class Fcitx5ConfigProxyPrivate;
 class Fcitx5ConfigProxy : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool saveTriggered READ saveTriggered NOTIFY saveTriggeredChanged)
 
 public:
     explicit Fcitx5ConfigProxy(fcitx::kcm::DBusProvider *dbus,
@@ -30,8 +31,11 @@ public:
 
     void clear();
 
+    bool saveTriggered() const;
+
 Q_SIGNALS:
     void requestConfigFinished();
+    void saveTriggeredChanged();
 
 public Q_SLOTS:
     QVariant value(const QString &path) const;
@@ -41,7 +45,7 @@ public Q_SLOTS:
     QVariantList globalConfigOptions(const QString &type, bool all = false) const;
     QVariant globalConfigOption(const QString &type, const QString &option) const;
     void restoreDefault(const QString &type);
-    void requestConfig(bool sync);
+    void requestConfig(bool sync, bool fromSave = false);
 
 private Q_SLOTS:
     void onRequestConfigFinished(QDBusPendingCallWatcher *watcher);
@@ -49,8 +53,9 @@ private Q_SLOTS:
 private:
     friend class Fcitx5ConfigProxyPrivate;
     Fcitx5ConfigProxyPrivate *const d;
+    bool m_saveTriggered = false;
 };
 }   // namespace fcitx5configtool
-}   // namespace deepin 
+}   // namespace deepin
 
 #endif // !FCITX5CONFIGPROXY_H

--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -11,8 +11,17 @@ import org.deepin.dcc 1.0
 DccObject {
     id: root
     property var configOptions: []
+    property var configValues: ({})
     property var keyName: ""
     property bool loading: true
+
+    function buildValuesMap(options) {
+        var vals = {}
+        for (var i = 0; i < options.length; i++) {
+            vals[options[i].name] = options[i].value
+        }
+        return vals
+    }
 
     DccObject {
         id: containerItem
@@ -72,16 +81,24 @@ DccObject {
             model: root.configOptions
             delegate: Component {
                 DccObject {
+                    id: optionDelegate
                     parentName: containerItem.name
                     displayName: modelData.description
                     weight: root.weight + index + 1
                     pageType: DccObject.Editor
                     visible: headerItem.expanded
                     backgroundType: DccObject.Normal | DccObject.Hover
+
+                    property string optName: modelData.name
+                    property string optType: modelData.type
+                    property var optValue: root.configValues[optName] !== undefined
+                                           ? root.configValues[optName]
+                                           : modelData.value
+
                     page: Loader {
                         height: 40
                         sourceComponent: {
-                            switch (modelData.type) {
+                            switch (optionDelegate.optType) {
                             case "Boolean":
                                 return booleanComponent
                             case "Integer":
@@ -100,10 +117,10 @@ DccObject {
                         Component {
                             id: booleanComponent
                             D.Switch {
-                                checked: modelData.value === "True"
+                                checked: optionDelegate.optValue === "True"
                                 onCheckedChanged: {
                                     dccData.fcitx5ConfigProxy.setValue(
-                                                root.name + "/" + modelData.name,
+                                                root.name + "/" + optionDelegate.optName,
                                                 checked ? "True" : "False")
                                 }
                             }
@@ -117,10 +134,10 @@ DccObject {
                                 implicitWidth: 75
                                 from: modelData.intMin !== undefined ? modelData.intMin : 0
                                 to: modelData.intMax !== undefined ? modelData.intMax : 9999
-                                value: parseInt(modelData.value)
+                                value: parseInt(optionDelegate.optValue)
                                 onValueChanged: {
                                     dccData.fcitx5ConfigProxy.setValue(
-                                                root.name + "/" + modelData.name,
+                                                root.name + "/" + optionDelegate.optName,
                                                 value.toString())
                                 }
                             }
@@ -129,10 +146,10 @@ DccObject {
                         Component {
                             id: stringComponent
                             D.TextField {
-                                text: modelData.value
+                                text: optionDelegate.optValue
                                 onTextChanged: {
                                     dccData.fcitx5ConfigProxy.setValue(
-                                                root.name + "/" + modelData.name,
+                                                root.name + "/" + optionDelegate.optName,
                                                 text)
                                 }
                             }
@@ -142,27 +159,27 @@ DccObject {
                             id: keyComponent
                             KeySequenceDisplay {
                                 placeholderText: qsTr("Please enter a new shortcut")
-                                keys: modelData.value
+                                keys: optionDelegate.optValue
                                 background.visible: false
                                 onFocusChanged: {
                                     if (!focus) {
                                         if (keys.length > 0) {
                                             dccData.fcitx5ConfigProxy.setValue(
-                                                        root.name + "/" + modelData.name + "/0",
+                                                        root.name + "/" + optionDelegate.optName + "/0",
                                                         keys, true)
-                                        } else if (root.keyName != modelData.name) {
-                                            keys = modelData.value
+                                        } else if (root.keyName != optionDelegate.optName) {
+                                            keys = optionDelegate.optValue
                                         }
                                     }
                                 }
                                 onKeysChanged: {
-                                    root.keyName = modelData.name
+                                    root.keyName = optionDelegate.optName
                                 }
 
                                 Connections {
                                     target: root
                                     function onKeyNameChanged() {
-                                        if (root.keyName != modelData.name) {
+                                        if (root.keyName != optionDelegate.optName) {
                                             focus = false
                                         }
                                     }
@@ -176,11 +193,11 @@ DccObject {
                                 model: modelData.propertiesI18n
                                 flat: true
                                 currentIndex: modelData.properties.indexOf(
-                                                  modelData.value) ? modelData.properties.indexOf(
-                                                                         modelData.value) : 0
+                                                  optionDelegate.optValue) ? modelData.properties.indexOf(
+                                                                                 optionDelegate.optValue) : 0
                                 onCurrentIndexChanged: {
                                     dccData.fcitx5ConfigProxy.setValue(
-                                                root.name + "/" + modelData.name,
+                                                root.name + "/" + optionDelegate.optName,
                                                 modelData.properties[currentIndex])
                                 }
                             }
@@ -193,14 +210,20 @@ DccObject {
     Connections {
         target: dccData.fcitx5ConfigProxy
         function onRequestConfigFinished() {
-            configOptions = []
-            configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
-            keyName = ""
+            var newOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
+            configValues = buildValuesMap(newOptions)
+
+            if (!dccData.fcitx5ConfigProxy.saveTriggered) {
+                configOptions = newOptions
+                keyName = ""
+            }
         }
     }
 
     Component.onCompleted: {
-        configOptions = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
+        var opts = dccData.fcitx5ConfigProxy.globalConfigOptions(root.name)
+        configValues = buildValuesMap(opts)
+        configOptions = opts
         loading = false
     }
 }


### PR DESCRIPTION
Track save-triggered state via new saveTriggered property. After save completes, requestConfig refreshes configValues only, skipping configOptions and keyName reset to prevent list re-render.

修复保存按钮点击后全局配置页面跳转问题，通过新增 saveTriggered 属性跟踪保存触发状态， 保存后的 requestConfig 仅刷新 configValues，跳过 configOptions 和 keyName 重置以避免列表重渲染。

Log: 修复全局配置页保存后页面跳转bug
PMS: BUG-361757
Influence: save 操作返回的 config 响应不再重置选项列表和快捷键焦点状态，
          避免用户看到的列表重新渲染和页面视觉跳转。