### PR TITLE
chore(keyboard): remove unused WM DBus proxy and compositing signal

### DIFF
--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboarddbusproxy.cpp
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboarddbusproxy.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -23,9 +23,6 @@ const static QString KeybingdingService = "org.deepin.dde.Keybinding1";
 const static QString KeybingdingPath = "/org/deepin/dde/Keybinding1";
 const static QString KeybingdingInterface = "org.deepin.dde.Keybinding1";
 
-const static QString WMService = "com.deepin.wm";
-const static QString WMPath = "/com/deepin/wm";
-const static QString WMInterface = "com.deepin.wm";
 
 KeyboardDBusProxy::KeyboardDBusProxy(QObject *parent)
     : QObject(parent)
@@ -47,9 +44,7 @@ void KeyboardDBusProxy::init()
     m_dBusLangSelectorInter = new DDBusInterface(LangSelectorService, LangSelectorPath, LangSelectorInterface, QDBusConnection::sessionBus(), this);
     m_dBusKeyboardInter = new DDBusInterface(KeyboardService, KeyboardPath, KeyboardInterface, QDBusConnection::sessionBus(), this);
     m_dBusKeybingdingInter = new DDBusInterface(KeybingdingService, KeybingdingPath, KeybingdingInterface, QDBusConnection::sessionBus(), this);
-    m_dBusWMInter = new DDBusInterface(WMService, WMPath, WMInterface, QDBusConnection::sessionBus(), this);
 
-    QDBusConnection::sessionBus().connect(WMService, WMPath, WMInterface, "wmCompositingEnabledChanged", this, SIGNAL(compositingEnabledChanged(bool)));
 }
 
 void KeyboardDBusProxy::langSelectorStartServiceProcess()

--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboarddbusproxy.h
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboarddbusproxy.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -153,9 +153,6 @@ Q_SIGNALS:
     void Deleted(const QString &in0, int in1);
     void KeyEvent(bool in0, const QString &in1);
 
-    //wm
-    void compositingEnabledChanged(bool enabled);
-
     void langSelectorServiceStartFinished(const quint32 ret) const;
 
 public Q_SLOTS:
@@ -196,7 +193,6 @@ private:
     DDBusInterface *m_dBusLangSelectorInter;
     DDBusInterface *m_dBusKeyboardInter;
     DDBusInterface *m_dBusKeybingdingInter;
-    DDBusInterface *m_dBusWMInter;
 };
 
 Q_DECLARE_METATYPE(KeyboardLayoutList)


### PR DESCRIPTION
Remove dead com.deepin.wm DBus interface, signal declaration, and connection that had no consumers.

移除无消费者的 com.deepin.wm DBus 接口、信号声明和连接。

Log: 移除 WM 死代码
PMS: TASK-390511
Influence: 减少不必要的 DBus 连接和对象创建，无功能影响。