### PR TITLE
chore(keyboard): remove unused windowSwitch dead code in ShortcutModel

### DIFF
--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardcontroller.cpp
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/keyboardcontroller.cpp
@@ -203,7 +203,6 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
     connect(m_shortcutModel, &ShortcutModel::delCustomInfo, sourceModel, &ShortcutListModel::reset);
     connect(m_shortcutModel, &ShortcutModel::addCustomInfo, sourceModel, &ShortcutListModel::reset);
     connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::reset);
-    connect(m_shortcutModel, &ShortcutModel::windowSwitchChanged, sourceModel, &ShortcutListModel::reset);
 
     m_shortcutSearchModel->setSourceModel(sourceModel);
     m_shortcutSearchModel->setFilterRole(ShortcutListModel::SearchedTextRole);

--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/shortcutmodel.cpp
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/shortcutmodel.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -96,7 +96,6 @@ using namespace dccV25;
 DCORE_USE_NAMESPACE
 ShortcutModel::ShortcutModel(QObject *parent)
     : QObject(parent)
-    , m_windowSwitchState(false)
 {
 }
 
@@ -277,14 +276,8 @@ void ShortcutModel::onParseInfo(const QString &info)
     // More efficient implementation using std::find_if
     auto it = std::find_if(m_systemInfos.begin(), m_systemInfos.end(),
         [](const ShortcutInfo* info) { return info->id == "preview-workspace"; });
-    m_windowSwitchStateInfos.clear();
     if (it != m_systemInfos.end()) {
-        int index = std::distance(m_systemInfos.begin(), it);
-        (*it)->index = index;
-        m_windowSwitchStateInfos << *it;
-        if (!m_windowSwitchState) {
-            m_systemInfos.erase(it);  // More efficient than removeOne
-        }
+        m_systemInfos.erase(it);
     }
 
     std::sort(m_windowInfos.begin(), m_windowInfos.end(), [ = ](ShortcutInfo *s1, ShortcutInfo *s2) {
@@ -361,32 +354,6 @@ void ShortcutModel::onKeyBindingChanged(const QString &value)
         Q_EMIT shortcutChanged((*res));
     }
 }
-
-void ShortcutModel::onWindowSwitchChanged(bool value)
-{
-    if (m_windowSwitchState != value) {
-        m_windowSwitchState = value;
-        if (m_windowSwitchState) {
-            for (int i = m_windowSwitchStateInfos.size() - 1; i >= 0; i--) {
-                m_systemInfos.insert(m_windowSwitchStateInfos.at(i)->index, m_windowSwitchStateInfos.at(i));
-            }
-        } else {
-            for (int i = 0; i < m_windowSwitchStateInfos.size(); i++) {
-                m_systemInfos.removeOne(m_windowSwitchStateInfos.at(i));
-            }
-        }
-        
-        // 系统快捷键列表发生变化，清理缓存
-        invalidateSystemShortcutNamesCache();
-        
-        Q_EMIT windowSwitchChanged(m_windowSwitchState);
-    }
-}
-
- bool ShortcutModel::getWindowSwitch()
- {
-     return m_windowSwitchState;
- }
 
  QStringList ShortcutModel::formatKeys(const QString &shortcut)
  {

--- a/src/dcc-fcitx5configtool/keyboard-layout/operation/shortcutmodel.h
+++ b/src/dcc-fcitx5configtool/keyboard-layout/operation/shortcutmodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -85,8 +85,6 @@ public:
 
     void setSearchResult(const QString &searchResult);
     bool searchResultContains(const QString &id);
-    bool getWindowSwitch();
-
     // 新增：获取所有系统快捷键名称列表
     QStringList getSystemShortcutNames() const;
 
@@ -101,13 +99,10 @@ Q_SIGNALS:
     void shortcutChanged(ShortcutInfo *info);
     void keyEvent(bool press, const QString &shortcut);
     void searchFinished(const QList<ShortcutInfo *> searchResult);
-    void windowSwitchChanged(bool value);
-
 public Q_SLOTS:
     void onParseInfo(const QString &info);
     void onCustomInfo(const QString &json);
     void onKeyBindingChanged(const QString &value);
-    void onWindowSwitchChanged(bool value);
 
 private:
     // 清理系统快捷键名称缓存
@@ -120,9 +115,7 @@ private:
     QList<ShortcutInfo *> m_assistiveToolsInfos;
     QList<ShortcutInfo *> m_customInfos;
     QList<ShortcutInfo *> m_searchList;
-    QList<ShortcutInfo *> m_windowSwitchStateInfos;
     ShortcutInfo *m_currentInfo = nullptr;
-    bool m_windowSwitchState;
 
     // 系统快捷键名称缓存
     mutable QSet<QString> m_systemNamesCache;


### PR DESCRIPTION
Remove onWindowSwitchChanged, getWindowSwitch, windowSwitchChanged signal and related members that have no callers or signal connections.

移除 ShortcutModel 中无调用者和信号连接的 windowSwitch 相关死代码。

Log: 移除 windowSwitch 死代码
PMS: TASK-390511
Influence: 纯代码清理，无功能影响。