### PR TITLE
fix(im-list): resolve item height inconsistency

### DIFF
--- a/src/dcc-fcitx5configtool/qml/IMList.qml
+++ b/src/dcc-fcitx5configtool/qml/IMList.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.3
@@ -26,7 +26,7 @@ Rectangle {
         D.ItemDelegate {
             id: delegateItem
             width: listView.width
-            height: content.height
+            height: 40
             cascadeSelected: true
             checkable: false
             contentFlow: true
@@ -35,6 +35,7 @@ Rectangle {
                                              dccData.imlistModel().count())
 
             background: DccItemBackground {
+                implicitHeight: delegateItem.height
                 separatorVisible: true
                 backgroundType: DccObject.Normal | DccObject.Hover
             }
@@ -191,7 +192,7 @@ Rectangle {
         width: parent.width
         height: contentHeight
         model: visualModel
-        spacing: 4
+        spacing: 0
         interactive: true
         clip: true
         cacheBuffer: 50


### PR DESCRIPTION
Fix delegate height to 40px and remove ListView spacing to match DccItemBackground separator rendering.

修复输入法管理列表条目高度不一致和hover背景间隙问题，
固定delegate高度并移除列表间距。

Log: 修复输入法列表条目高度不一致和hover背景间隙
PMS: BUG-305809
Influence: 输入法管理列表条目高度统一为40px，hover背景正确填充。

## Summary by Sourcery

Unify item heights and hover background behavior in the input method management list to match the design separators.

Bug Fixes:
- Fix inconsistent item heights in the input method management list by standardizing row height.
- Eliminate gaps in the hover background between items in the input method management list.