### PR TITLE
chore(im-list): remove redundant implicitHeight on DccItemBackground

### DIFF
--- a/src/dcc-fcitx5configtool/qml/IMList.qml
+++ b/src/dcc-fcitx5configtool/qml/IMList.qml
@@ -35,7 +35,6 @@ Rectangle {
                                              dccData.imlistModel().count())
 
             background: DccItemBackground {
-                implicitHeight: delegateItem.height
                 separatorVisible: true
                 backgroundType: DccObject.Normal | DccObject.Hover
             }


### PR DESCRIPTION
Qt Quick Controls 2 auto-anchors background to fill the delegate, making explicit implicitHeight a no-op.

移除DccItemBackground上多余的implicitHeight绑定，该属性无实际效果。

Log: 移除冗余implicitHeight属性
PMS: BUG-305809
Influence: 无功能影响，仅清理无效代码。

## Summary by Sourcery

Enhancements:
- Simplify the IM list delegate background by relying on Qt Quick Controls 2 default sizing instead of an explicit implicitHeight.