### PR TITLE
fix(keyboard): normalize modifier keys in shortcut formatting

### DIFF
--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
@@ -59,7 +59,25 @@ QStringList Fcitx5ConfigProxyPrivate::formatKey(const QString &shortcut) {
         if (list.contains("Alt_L")) {
             list.removeAll("Alt_L");
         } else {
+            list.removeAll("Alt_R");
+        }
+    } else if (list.size() == 2 && list.contains("Ctrl")) {
+        if (list.contains("Control_L")) {
+            list.removeAll("Control_L");
+        } else if (list.contains("Control_R")) {
+            list.removeAll("Control_R");
+        }
+    } else if (list.size() == 2 && list.contains("Shift")) {
+        if (list.contains("Shift_L")) {
+            list.removeAll("Shift_L");
+        } else if (list.contains("Shift_R")) {
             list.removeAll("Shift_R");
+        }
+    } else if (list.size() == 2 && list.contains("Alt")) {
+        if (list.contains("Alt_L")) {
+            list.removeAll("Alt_L");
+        } else if (list.contains("Alt_R")) {
+            list.removeAll("Alt_R");
         }
     }
     qCDebug(proxy) << "Formatted key list:" << list;
@@ -86,6 +104,12 @@ QString Fcitx5ConfigProxyPrivate::formatKeys(const QStringList &keys) {
     } else if (list.size() == 2 && list.contains("Control") && list.contains("Super")) {
         list.append("Control_L");
     } else if (list.size() == 2 && list.contains("Alt") && list.contains("Super")) {
+        list.append("Alt_L");
+    } else if (list.size() == 1 && list.contains("Shift")) {
+        list.append("Shift_L");
+    } else if (list.size() == 1 && list.contains("Control")) {
+        list.append("Control_L");
+    } else if (list.size() == 1 && list.contains("Alt")) {
         list.append("Alt_L");
     }
 


### PR DESCRIPTION
Fix Alt_R not being removed in formatKey, and add normalization for single modifier keys (Ctrl/Shift/Alt) in both formatKey and formatKeys.

修复快捷键格式化中Alt_R未正确移除的问题，并为formatKey和formatKeys
补充Ctrl/Shift/Alt单修饰键的规范化处理。

Log: 修复修饰键快捷键格式化
PMS: BUG-352483
Influence: 修复快捷键设置中修饰键显示和存储不正确的问题。

## Summary by Sourcery

Normalize modifier-only keyboard shortcuts to consistently handle left/right variants of Ctrl, Shift, and Alt in formatting utilities.

Bug Fixes:
- Ensure Alt_R is correctly removed when normalizing Alt-based shortcuts in formatKey.
- Normalize single-modifier shortcuts (Ctrl/Shift/Alt) in formatKey and formatKeys so stored/displayed shortcuts are consistent.