### PR TITLE
fix(keyboard): guard side-variant removal in size==3 modifier branches

### DIFF
--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
@@ -46,19 +46,19 @@ QStringList Fcitx5ConfigProxyPrivate::formatKey(const QString &shortcut) {
     if (list.size() == 3 && list.contains("Ctrl") && list.contains("Meta")) {
         if (list.contains("Control_L")) {
             list.removeAll("Control_L");
-        } else {
+        } else if (list.contains("Control_R")) {
             list.removeAll("Control_R");
         }
     } else if (list.size() == 3 && list.contains("Shift") && list.contains("Meta")) {
         if (list.contains("Shift_L")) {
             list.removeAll("Shift_L");
-        } else {
+        } else if (list.contains("Shift_R")) {
             list.removeAll("Shift_R");
         }
     } else if (list.size() == 3 && list.contains("Alt") && list.contains("Meta")) {
         if (list.contains("Alt_L")) {
             list.removeAll("Alt_L");
-        } else {
+        } else if (list.contains("Alt_R")) {
             list.removeAll("Alt_R");
         }
     } else if (list.size() == 2 && list.contains("Ctrl")) {


### PR DESCRIPTION
Change unconditional else to else-if contains check in size==3 Ctrl/Shift/Alt branches, aligning with size==2 branches.

将size==3修饰键分支的无条件else改为else-if确认检查，与size==2分支对齐。

Log: 统一修饰键side移除的条件判断
PMS: BUG-352483
Influence: 避免第三个token非side变体时误触发移除，提升格式化逻辑一致性。

## Summary by Sourcery

Bug Fixes:
- Prevent unintended removal of non-side modifiers when normalizing three-key Ctrl/Shift/Alt + Meta shortcuts by only removing the specific L/R variant if present.