### PR TITLE
refactor(shortcut): dedupe modifier side-variant handling in formatKe…

### DIFF
--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
@@ -43,42 +43,35 @@ QStringList Fcitx5ConfigProxyPrivate::formatKey(const QString &shortcut) {
         else
             list << key.trimmed();
     }
+    // Remove the present side variant (left takes priority). When the shortcut
+    // also carries Meta, surface Meta at the front so it reads "Meta+...+key".
+    auto removeSide = [&list](const QString &base, bool frontMeta) {
+        const QString left = base + "_L";
+        const QString right = base + "_R";
+        if (list.contains(left)) {
+            list.removeAll(left);
+        } else if (list.contains(right)) {
+            list.removeAll(right);
+        } else {
+            return;
+        }
+        if (frontMeta) {
+            list.removeAll("Meta");
+            list.prepend("Meta");
+        }
+    };
     if (list.size() == 3 && list.contains("Ctrl") && list.contains("Meta")) {
-        if (list.contains("Control_L")) {
-            list.removeAll("Control_L");
-        } else if (list.contains("Control_R")) {
-            list.removeAll("Control_R");
-        }
+        removeSide("Control", true);
     } else if (list.size() == 3 && list.contains("Shift") && list.contains("Meta")) {
-        if (list.contains("Shift_L")) {
-            list.removeAll("Shift_L");
-        } else if (list.contains("Shift_R")) {
-            list.removeAll("Shift_R");
-        }
+        removeSide("Shift", true);
     } else if (list.size() == 3 && list.contains("Alt") && list.contains("Meta")) {
-        if (list.contains("Alt_L")) {
-            list.removeAll("Alt_L");
-        } else if (list.contains("Alt_R")) {
-            list.removeAll("Alt_R");
-        }
+        removeSide("Alt", true);
     } else if (list.size() == 2 && list.contains("Ctrl")) {
-        if (list.contains("Control_L")) {
-            list.removeAll("Control_L");
-        } else if (list.contains("Control_R")) {
-            list.removeAll("Control_R");
-        }
+        removeSide("Control", false);
     } else if (list.size() == 2 && list.contains("Shift")) {
-        if (list.contains("Shift_L")) {
-            list.removeAll("Shift_L");
-        } else if (list.contains("Shift_R")) {
-            list.removeAll("Shift_R");
-        }
+        removeSide("Shift", false);
     } else if (list.size() == 2 && list.contains("Alt")) {
-        if (list.contains("Alt_L")) {
-            list.removeAll("Alt_L");
-        } else if (list.contains("Alt_R")) {
-            list.removeAll("Alt_R");
-        }
+        removeSide("Alt", false);
     }
     qCDebug(proxy) << "Formatted key list:" << list;
     return list;
@@ -99,18 +92,28 @@ QString Fcitx5ConfigProxyPrivate::formatKeys(const QStringList &keys) {
         else
             list << key.trimmed();
     }
+    // size==2 with Super: normalize to "<Modifier>+Super+<_L>" order regardless
+    // of input order, then append the left side variant. size==1 has no Super,
+    // just append the left side variant.
+    auto appendLeftSide = [&list](const QString &base, bool withSuper) {
+        if (withSuper) {
+            list.clear();
+            list << base << "Super";
+        }
+        list.append(base + "_L");
+    };
     if (list.size() == 2 && list.contains("Shift") && list.contains("Super")) {
-        list.append("Shift_L");
+        appendLeftSide("Shift", true);
     } else if (list.size() == 2 && list.contains("Control") && list.contains("Super")) {
-        list.append("Control_L");
+        appendLeftSide("Control", true);
     } else if (list.size() == 2 && list.contains("Alt") && list.contains("Super")) {
-        list.append("Alt_L");
+        appendLeftSide("Alt", true);
     } else if (list.size() == 1 && list.contains("Shift")) {
-        list.append("Shift_L");
+        appendLeftSide("Shift", false);
     } else if (list.size() == 1 && list.contains("Control")) {
-        list.append("Control_L");
+        appendLeftSide("Control", false);
     } else if (list.size() == 1 && list.contains("Alt")) {
-        list.append("Alt_L");
+        appendLeftSide("Alt", false);
     }
 
     return list.join("+");


### PR DESCRIPTION
…y/formatKeys

Extract removeSide/appendLeftSide lambdas to dedupe Ctrl/Shift/Alt branches, front Meta in size==3 and normalize order in size==2.

抽取 formatKey/formatKeys 中 Ctrl/Shift/Alt 分支为 removeSide/ appendLeftSide lambda，size==3 时将 Meta 前置，size==2 时统一为 Modifier+Super+_L 顺序。

Log: 重构快捷键修饰键格式化并统一显示顺序
PMS: BUG-352483
Influence: 快捷键设置中含 Meta 的组合键统一显示为 Meta 在前，存储方向统一为 Modifier+Super+_L 顺序。

## Summary by Sourcery

Refactor shortcut key formatting to deduplicate modifier side-variant handling and normalize display order, especially for Meta and Super combinations.

Bug Fixes:
- Ensure shortcuts containing Meta are consistently displayed with Meta first in three-key combinations and stored in a normalized modifier order for two-key combinations.

Enhancements:
- Extract reusable helpers for removing left/right modifier variants and appending left-side variants to simplify and unify shortcut formatting logic.