### PR TITLE
fix(shortcut): show Super label and simplify modifier lambdas

### DIFF
--- a/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
+++ b/src/dcc-fcitx5configtool/operation/fcitx5configproxy.cpp
@@ -45,7 +45,7 @@ QStringList Fcitx5ConfigProxyPrivate::formatKey(const QString &shortcut) {
     }
     // Remove the present side variant (left takes priority). When the shortcut
     // also carries Meta, surface Meta at the front so it reads "Meta+...+key".
-    auto removeSide = [&list](const QString &base, bool frontMeta) {
+    auto removeSide = [&list](const QString &base) {
         const QString left = base + "_L";
         const QString right = base + "_R";
         if (list.contains(left)) {
@@ -55,23 +55,23 @@ QStringList Fcitx5ConfigProxyPrivate::formatKey(const QString &shortcut) {
         } else {
             return;
         }
-        if (frontMeta) {
+        if (list.contains("Meta")) {
             list.removeAll("Meta");
             list.prepend("Meta");
         }
     };
     if (list.size() == 3 && list.contains("Ctrl") && list.contains("Meta")) {
-        removeSide("Control", true);
+        removeSide("Control");
     } else if (list.size() == 3 && list.contains("Shift") && list.contains("Meta")) {
-        removeSide("Shift", true);
+        removeSide("Shift");
     } else if (list.size() == 3 && list.contains("Alt") && list.contains("Meta")) {
-        removeSide("Alt", true);
+        removeSide("Alt");
     } else if (list.size() == 2 && list.contains("Ctrl")) {
-        removeSide("Control", false);
+        removeSide("Control");
     } else if (list.size() == 2 && list.contains("Shift")) {
-        removeSide("Shift", false);
+        removeSide("Shift");
     } else if (list.size() == 2 && list.contains("Alt")) {
-        removeSide("Alt", false);
+        removeSide("Alt");
     }
     qCDebug(proxy) << "Formatted key list:" << list;
     return list;
@@ -95,25 +95,25 @@ QString Fcitx5ConfigProxyPrivate::formatKeys(const QStringList &keys) {
     // size==2 with Super: normalize to "<Modifier>+Super+<_L>" order regardless
     // of input order, then append the left side variant. size==1 has no Super,
     // just append the left side variant.
-    auto appendLeftSide = [&list](const QString &base, bool withSuper) {
-        if (withSuper) {
+    auto appendLeftSide = [&list](const QString &base) {
+        if (list.contains("Super")) {
             list.clear();
             list << base << "Super";
         }
         list.append(base + "_L");
     };
     if (list.size() == 2 && list.contains("Shift") && list.contains("Super")) {
-        appendLeftSide("Shift", true);
+        appendLeftSide("Shift");
     } else if (list.size() == 2 && list.contains("Control") && list.contains("Super")) {
-        appendLeftSide("Control", true);
+        appendLeftSide("Control");
     } else if (list.size() == 2 && list.contains("Alt") && list.contains("Super")) {
-        appendLeftSide("Alt", true);
+        appendLeftSide("Alt");
     } else if (list.size() == 1 && list.contains("Shift")) {
-        appendLeftSide("Shift", false);
+        appendLeftSide("Shift");
     } else if (list.size() == 1 && list.contains("Control")) {
-        appendLeftSide("Control", false);
+        appendLeftSide("Control");
     } else if (list.size() == 1 && list.contains("Alt")) {
-        appendLeftSide("Alt", false);
+        appendLeftSide("Alt");
     }
 
     return list.join("+");

--- a/src/dcc-fcitx5configtool/qml/KeySequenceDisplay.qml
+++ b/src/dcc-fcitx5configtool/qml/KeySequenceDisplay.qml
@@ -1,5 +1,5 @@
 
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.11
 import QtQuick.Controls
@@ -53,7 +53,9 @@ Control {
                     model: control.keys
                     P.KeySequenceLabel {
                         Layout.alignment: Qt.AlignRight
-                        text: modelData
+                        // fcitx stores the Win key as "Super"; Qt/DTK calls it
+                        // "Meta". Show the user-facing "Super" label.
+                        text: modelData === "Meta" ? "Super" : modelData
                     }
                 }
             }


### PR DESCRIPTION
Render the Win key as "Super" in KeySequenceDisplay instead of Qt's internal "Meta" name. Also drop redundant bool flags from the proxy's removeSide/appendLeftSide lambdas by checking list contents directly.

快捷键显示界面将 Win 键显示为"Super"而非 Qt 内部的"Meta"命名；
同时移除代理层 removeSide/appendLeftSide lambda 中冗余的 bool 参数， 改为直接检查列表内容。

Log: 快捷键Win键显示为Super并简化modifier处理
PMS: BUG-333383
Influence: 快捷键设置界面中包含Win键的组合键现在显示为"Super"，更符合用户习惯；代理层modifier归一化逻辑更简洁，无行为变化。

## Summary by Sourcery

Update shortcut display to show the Win key as "Super" and simplify internal modifier normalization logic without changing behavior.

New Features:
- Display the Win key as "Super" instead of "Meta" in the shortcut display UI.

Enhancements:
- Simplify modifier side-handling lambdas by deriving behavior directly from the current key list rather than passing explicit flags.