### PR TITLE
feat(config): hide fcitx5 core shortcut config items

### DIFF
--- a/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailConfigItem.qml
@@ -15,12 +15,26 @@ DccObject {
     property var keyName: ""
     property bool loading: true
 
+    // Hidden config items (fcitx5 core shortcuts)
+    readonly property var hiddenConfigNames: [
+        "EnumerateGroupForwardKeys",
+        "EnumerateGroupBackwardKeys",
+        "ActivateKeys",
+        "DeactivateKeys"
+    ]
+
     function buildValuesMap(options) {
         var vals = {}
         for (var i = 0; i < options.length; i++) {
             vals[options[i].name] = options[i].value
         }
         return vals
+    }
+
+    function filterConfigOptions(options) {
+        return options.filter(function(opt) {
+            return opt.name && !hiddenConfigNames.includes(opt.name)
+        })
     }
 
     DccObject {
@@ -78,7 +92,7 @@ DccObject {
         DccRepeater {
             id: optionRepeater
             visible: !root.loading
-            model: root.configOptions
+            model: filterConfigOptions(root.configOptions)
             delegate: Component {
                 DccObject {
                     id: optionDelegate


### PR DESCRIPTION
Hide 4 fcitx5 core shortcut config items from UI to avoid user confusion. Backend config remains complete, only frontend display is filtered.

隐藏 4 个 fcitx5 核心快捷键配置项，避免用户误修改。后端配置保持完整，仅前端过滤显示。

Log: 隐藏 fcitx5 核心快捷键配置项
PMS: BUG-333383
Influence: 用户无法在控制中心修改 fcitx5 核心切换快捷键，需通过其他方式配置。