### PR TITLE
fix(ui): adjust Add-ons page spacing for better layout

### DIFF
--- a/src/dcc-fcitx5configtool/qml/AdvancedSettingsModule.qml
+++ b/src/dcc-fcitx5configtool/qml/AdvancedSettingsModule.qml
@@ -65,7 +65,7 @@ DccObject {
         displayName: qsTr("Add-ons")
         weight: 330
         page: DccRightView {
-            spacing: 0
+            spacing: 4
         }
         AddonsPage {}
     }


### PR DESCRIPTION
Set spacing to 4px for Add-ons page right panel.

调整 Add-ons 页面右侧面板间距为 4px。

Log: 调整 Add-ons 页面间距
PMS: BUG-305819
Influence: Add-ons 页面布局间距更合理，视觉效果改善。