### PR TITLE
fix(ui): adjust add-ons page item spacing and layout

### DIFF
--- a/src/dcc-fcitx5configtool/qml/AdvancedSettingsModule.qml
+++ b/src/dcc-fcitx5configtool/qml/AdvancedSettingsModule.qml
@@ -65,7 +65,7 @@ DccObject {
         displayName: qsTr("Add-ons")
         weight: 330
         page: DccRightView {
-            spacing: 4
+            spacing: 0
         }
         AddonsPage {}
     }

--- a/src/dcc-fcitx5configtool/qml/DetailAddonsItem.qml
+++ b/src/dcc-fcitx5configtool/qml/DetailAddonsItem.qml
@@ -32,13 +32,14 @@ DccObject {
                 property bool isHovered: false
                 onParentItemChanged: {
                     if (parentItem) {
+                        parentItem.topPadding = 8
+                        parentItem.bottomPadding = 8
                         parentItem.leftPadding = 4
                         parentItem.rightPadding = 4
                     }
                 }
                 page: RowLayout {
                     width: parent.parentItem.width
-                    height: 50
                     spacing: 0
                     CheckBox {
                         Layout.alignment: Qt.AlignLeft
@@ -67,16 +68,21 @@ DccObject {
                     Item {
                         Layout.fillWidth: true
                     }
-                    D.ToolButton {
-                        id: imManageButton
+                    Item {
                         Layout.alignment: Qt.AlignRight
-                        icon.name: "dcc_input_method_settings"
-                        visible: modelData.configurable && isHovered
-                        enabled: modelData.enabled
-                        onClicked: {
-                            dccData.showAddonSettingsDialog(
-                                        modelData.uniqueName,
-                                        modelData.name)
+                        implicitWidth: imManageButton.implicitWidth
+                        implicitHeight: imManageButton.implicitHeight
+                        D.ToolButton {
+                            id: imManageButton
+                            anchors.fill: parent
+                            icon.name: "dcc_input_method_settings"
+                            visible: modelData.configurable && isHovered
+                            enabled: modelData.enabled
+                            onClicked: {
+                                dccData.showAddonSettingsDialog(
+                                            modelData.uniqueName,
+                                            modelData.name)
+                            }
                         }
                     }
                     MouseArea {


### PR DESCRIPTION
Remove fixed row height, use padding for consistent item sizing, and wrap settings button in centered container.

调整附加组件页面项间距和布局，移除固定行高，使用内边距
保持统一的项目尺寸，并将设置按钮包裹在居中容器中。

Log: 调整附加组件页面项间距和布局
PMS: BUG-305819
Influence: 附加组件列表项不再有固定高度，改用内边距控制
间距，设置按钮居中显示，布局更加统一。